### PR TITLE
Fixed formating

### DIFF
--- a/scripts/Initialize-Symlinks.ps1
+++ b/scripts/Initialize-Symlinks.ps1
@@ -91,11 +91,11 @@ function New-Symlink {
 
     try {
         New-Item -ItemType SymbolicLink -Path $LinkPath -Target $TargetPath -Force | Out-Null
-        Write-Host "[OK] Created symlink: $LinkPath -> $TargetPath" -ForegroundColor Greeneen
+        Write-Host "[OK] Created symlink: $LinkPath -> $TargetPath" -ForegroundColor Green
         return $true
     }
     catch {
-        Write-Host "[FAIL] Failed to create symlink for $LinkPath" -ForegroundColor Redr Red
+        Write-Host "[FAIL] Failed to create symlink for $LinkPath" -ForegroundColor Red
         Write-Host "  Error: $($_.Exception.Message)" -ForegroundColor Red
         return $false
     }
@@ -134,7 +134,7 @@ function Register-LoginTask {
             Write-Host "Removed existing scheduled task: $taskName" -ForegroundColor Yellow
         }
         catch {
-            Write-Host "[FAIL] Failed to remove existing scheduled task" -ForegroundColor Redr Red
+            Write-Host "[FAIL] Failed to remove existing scheduled task" -ForegroundColor Red
             return $false
         }
     }
@@ -163,11 +163,11 @@ function Register-LoginTask {
             -Description "Automatically pull latest changes from gitconfig repository at user login" `
             -Force | Out-Null
 
-        Write-Host "[OK] Created scheduled task: $taskName" -ForegroundColor Greeneen
+        Write-Host "[OK] Created scheduled task: $taskName" -ForegroundColor Green
         return $true
     }
     catch {
-        Write-Host "[FAIL] Failed to create scheduled task" -ForegroundColor Redr Red
+        Write-Host "[FAIL] Failed to create scheduled task" -ForegroundColor Red
         Write-Host "  Error: $($_.Exception.Message)" -ForegroundColor Red
         return $false
     }
@@ -180,7 +180,7 @@ foreach ($file in $filesToLink) {
     $linkPath = Join-Path $homeDir $file
 
     if (-not (Test-Path $targetPath)) {
-        Write-Host "[FAIL] Source file not found: $targetPath" -ForegroundColor Redr Red
+        Write-Host "[FAIL] Source file not found: $targetPath" -ForegroundColor Red
         continue
     }
 
@@ -206,7 +206,7 @@ if ($taskResponse -eq "y") {
     }
     else {
         if (Register-LoginTask -RepoRoot $repoRoot -Force $Force) {
-            Write-Host "[OK] Scheduled task created successfully!" -ForegroundColor Greeneen
+            Write-Host "[OK] Scheduled task created successfully!" -ForegroundColor Green
         }
     }
     Write-Host ""
@@ -219,9 +219,9 @@ Write-Host ""
 # Test the symlink by running 'git alias'
 Write-Host "Testing symlink setup..." -ForegroundColor Cyan
 try {
-    $testOutput = git alias 2>&1
+    git alias 2>&1 | Out-Null
     if ($LASTEXITCODE -eq 0) {
-        Write-Host "[OK] Symlinks verified! Git aliases are working." -ForegroundColor Greeneen
+        Write-Host "[OK] Symlinks verified! Git aliases are working." -ForegroundColor Green
     }
     else {
         Write-Host "[WARN] git alias command failed. Verify symlinks manually with: git alias" -ForegroundColor Yellow


### PR DESCRIPTION
This pull request fixes several typos in the `Write-Host` statements in `scripts/Initialize-Symlinks.ps1` where invalid color names like `Greeneen` and `Redr Red` were used. All color names are now corrected to valid PowerShell color values, ensuring that status messages display with the intended colors.

**Console output and color fixes:**

* Corrected all instances of invalid `-ForegroundColor` values such as `Greeneen` and `Redr Red` to valid values like `Green` and `Red` in status messages throughout the script. [[1]](diffhunk://#diff-5e892936623acb7e43db40492e849340fb089696f2790e528799857907fa42afL94-R98) [[2]](diffhunk://#diff-5e892936623acb7e43db40492e849340fb089696f2790e528799857907fa42afL137-R137) [[3]](diffhunk://#diff-5e892936623acb7e43db40492e849340fb089696f2790e528799857907fa42afL166-R170) [[4]](diffhunk://#diff-5e892936623acb7e43db40492e849340fb089696f2790e528799857907fa42afL183-R183) [[5]](diffhunk://#diff-5e892936623acb7e43db40492e849340fb089696f2790e528799857907fa42afL209-R209) [[6]](diffhunk://#diff-5e892936623acb7e43db40492e849340fb089696f2790e528799857907fa42afL222-R224)
* Minor adjustment in the symlink verification section: output from `git alias` is now discarded with `Out-Null` for cleaner logs.