### PR TITLE
feat: Create and symlink .gitignore_global file

### DIFF
--- a/.gitignore_global
+++ b/.gitignore_global
@@ -1,0 +1,288 @@
+# Global .gitignore patterns for common IDEs, OS files, and development tools
+# This file is meant to be used with: git config --global core.excludesfile ~/.gitignore_global
+
+# ============================================================================
+# IDE and Editor Files
+# ============================================================================
+
+# VS Code
+.vscode/
+*.code-workspace
+.VSCodeCounter/
+
+# JetBrains IDEs (IntelliJ, PyCharm, WebStorm, etc.)
+.idea/
+*.iml
+*.iws
+*.ipr
+*.swp
+*.swo
+*~
+
+# Vim
+.vim/
+*.vim
+.vimrc
+.netrwhist
+*~
+*.swp
+*.swo
+
+# Sublime Text
+*.sublime-project
+*.sublime-workspace
+
+# Emacs
+*~
+\#*\#
+.\#*
+
+# Atom
+.atom/
+
+# Eclipse
+.classpath
+.project
+.settings/
+.vscode/
+
+# Notepad++
+*.bak
+
+# ============================================================================
+# OS-Specific Files
+# ============================================================================
+
+# macOS
+.DS_Store
+.AppleDouble
+.LSOverride
+.Spotlight-V100
+.Trashes
+.VolumeIcon.icns
+.TemporaryItems
+*.swp
+*~.nib
+
+# Windows
+Thumbs.db
+ehthumbs.db
+Desktop.ini
+$RECYCLE.BIN/
+*.lnk
+*.exe
+*.bat
+*.cmd
+*.com
+
+# Linux
+.directory
+
+# ============================================================================
+# Python
+# ============================================================================
+
+__pycache__/
+*.py[cod]
+*$py.class
+*.so
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+pip-wheel-metadata/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+.pytest_cache/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.tox/
+.nox/
+.pylint.d/
+.mypy_cache/
+.dmypy.json
+dmypy.json
+.pyre/
+venv/
+ENV/
+env/
+.venv
+*.pyo
+
+# ============================================================================
+# Node.js / npm
+# ============================================================================
+
+node_modules/
+npm-debug.log
+npm-debug.log.*
+yarn-debug.log
+yarn-error.log
+.npm
+package-lock.json
+yarn.lock
+
+# ============================================================================
+# Ruby / Bundler
+# ============================================================================
+
+Gemfile.lock
+.bundle/
+vendor/bundle/
+
+# ============================================================================
+# Go
+# ============================================================================
+
+*.o
+*.a
+*.so
+*.dylib
+*.test
+*.out
+/dist/
+
+# ============================================================================
+# Java
+# ============================================================================
+
+*.class
+*.jar
+*.war
+*.ear
+.classpath
+.project
+.gradle/
+build/
+*.log
+
+# ============================================================================
+# C / C++
+# ============================================================================
+
+*.o
+*.a
+*.so
+*.dylib
+*.exe
+*.out
+*.app
+
+# ============================================================================
+# Build and Compilation Outputs
+# ============================================================================
+
+bin/
+obj/
+build/
+dist/
+target/
+out/
+.gradle
+*.log
+*.out
+*.tmp
+*.swp
+
+# ============================================================================
+# Dependency Management
+# ============================================================================
+
+vendor/
+node_modules/
+.bundle/
+*.lock
+Gemfile.lock
+
+# ============================================================================
+# Local Configuration Files
+# ============================================================================
+
+.env
+.env.local
+.env.*.local
+.secrets
+config/local/
+local_config.yaml
+private.key
+*.pem
+*.key
+credentials.json
+oauth_token
+.aws/credentials
+.ssh/
+.pgpass
+
+# ============================================================================
+# Temporary and Cache Files
+# ============================================================================
+
+*.tmp
+*.temp
+*.cache
+.cache/
+*.bak
+*.backup
+*.orig
+*.swp
+*.swo
+*~
+.DS_Store
+Thumbs.db
+.directory
+
+# ============================================================================
+# IDE-Specific Project Files
+# ============================================================================
+
+.classpath
+.project
+.factorypath
+.sts4-cache/
+.springBeans
+.sts4-cache
+
+# ============================================================================
+# Testing
+# ============================================================================
+
+.coverage
+.coverage.*
+htmlcov/
+.tox/
+.hypothesis/
+.pytest_cache/
+
+# ============================================================================
+# Documentation
+# ============================================================================
+
+site/
+docs/_build/
+dist/
+
+# ============================================================================
+# Misc
+# ============================================================================
+
+*.md.swp
+.vimrc.custom
+Session.vim

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Personal Git configuration and utilities for cross-machine synchronization.
 ## Contents
 
 - **`.gitconfig`** - Git configuration with custom aliases and SSH signing setup
+- **`.gitignore_global`** - Global gitignore patterns for IDEs, OS files, and development tools
 - **`.gitconfig_helper.py`** - Python utility for managing git aliases and branch cleanup
 - **`scripts/`** - PowerShell automation scripts
   - **`Initialize-Symlinks.ps1`** - Setup script for creating symlinks on Windows
@@ -76,6 +77,7 @@ $repo = "$env:USERPROFILE\Documents\Scripts\gitconfig"
 $home = $env:USERPROFILE
 
 New-Item -ItemType SymbolicLink -Path "$home\.gitconfig" -Target "$repo\.gitconfig" -Force
+New-Item -ItemType SymbolicLink -Path "$home\.gitignore_global" -Target "$repo\.gitignore_global" -Force
 New-Item -ItemType SymbolicLink -Path "$home\.gitconfig_helper.py" -Target "$repo\gitconfig_helper.py" -Force
 ```
 
@@ -110,10 +112,12 @@ git cleanup        # Clean up local branches
 The configuration uses a two-file approach for cross-machine portability:
 
 ### Shared Configuration (`.gitconfig`)
+
 - User information, aliases, and common settings
 - Tracked in Git for consistency across machines
 
 ### Machine-Specific Configuration (`.gitconfig.local`)
+
 - Safe directories and local paths
 - Created by `Initialize-LocalConfig.ps1`
 - NOT tracked in Git (excluded in `.gitignore`)
@@ -133,6 +137,22 @@ The `.gitconfig` includes `~/.gitconfig.local` for machine-specific settings:
 ```
 
 This is a Git best practice for handling environment-specific configurations.
+
+### Global Gitignore
+
+The `.gitignore_global` file is symlinked to `~/.gitignore_global` and automatically configured in `.gitconfig.local`. It contains patterns for:
+
+- **IDE and Editor Files** - VS Code, JetBrains, Sublime, Vim, Emacs, Atom
+- **OS-Specific Files** - macOS (.DS_Store), Windows (Thumbs.db), Linux (.directory)
+- **Language-Specific Artifacts**:
+  - Python: `__pycache__`, `*.pyc`, `.venv`, `venv/`
+  - Node.js: `node_modules/`, `npm-debug.log`
+  - Go, Java, Ruby, C/C++, and more
+- **Build Outputs** - `build/`, `dist/`, `target/`, compiled objects
+- **Local Configuration Files** - `.env`, `.secrets`, credentials, private keys
+- **Temporary Files** - `.tmp`, `.cache`, `.bak`, swap files
+
+These patterns prevent common development artifacts from being accidentally committed to repositories.
 
 ### SSH Signing
 
@@ -210,6 +230,7 @@ The project is in initial development (0.x.y pre-release phase). Versions will p
 - `v0.1.0-alpha` → `v0.1.0-beta` → `v0.1.0-rc.1` → `v0.1.0` (stable)
 
 Once stable `v1.0.0` is released, semantic versioning will strictly follow:
+
 - **MAJOR** - Breaking changes
 - **MINOR** - New backward-compatible features
 - **PATCH** - Bug fixes

--- a/scripts/Initialize-LocalConfig.ps1
+++ b/scripts/Initialize-LocalConfig.ps1
@@ -63,6 +63,10 @@ try {
 # Machine-Specific Git Configuration
 # This file is automatically included by .gitconfig and should NOT be committed
 
+[core]
+	# Use global gitignore file
+	excludesfile = $($homeDir -replace '\\', '/')/.gitignore_global
+
 [gpg "ssh"]
 	# Machine-specific SSH signing program path
 	program = $($homeDir -replace '\\', '/')/AppData/Local/Microsoft/WindowsApps/op-ssh-sign.exe

--- a/scripts/Initialize-Symlinks.ps1
+++ b/scripts/Initialize-Symlinks.ps1
@@ -37,6 +37,7 @@ EXAMPLE:
 
 FILES LINKED:
     - .gitconfig
+    - .gitignore_global
     - gitconfig_helper.py
 
 SCHEDULED TASKS:
@@ -66,6 +67,7 @@ Write-Host ""
 # Define files to symlink
 $filesToLink = @(
     ".gitconfig",
+    ".gitignore_global",
     "gitconfig_helper.py"
 )
 

--- a/scripts/Setup-GitConfig.ps1
+++ b/scripts/Setup-GitConfig.ps1
@@ -85,6 +85,7 @@ Write-Host ""
 # Define files to symlink
 $filesToLink = @(
     @{ File = ".gitconfig" },
+    @{ File = ".gitignore_global" },
     @{ File = "gitconfig_helper.py" }
 )
 
@@ -154,6 +155,9 @@ else {
     try {
         $configContent = @"
 # Machine-Specific Git Configuration
+[core]
+	excludesfile = $($homeDir -replace '\\', '/')/.gitignore_global
+
 [gpg]
 	format = ssh
 


### PR DESCRIPTION
- Create comprehensive .gitignore_global with patterns for:
  - IDEs (VS Code, JetBrains, Vim, Sublime, Emacs, Atom)
  - OS-specific files (macOS, Windows, Linux)
  - Language artifacts (Python, Node.js, Go, Java, Ruby, C/C++)
  - Build outputs and temporary files
  - Local configuration and credentials

- Update Initialize-Symlinks.ps1 to symlink .gitignore_global
- Update Setup-GitConfig.ps1 to include .gitignore_global in setup
  - Add [core] section with excludesfile configuration

- Update Initialize-LocalConfig.ps1 to configure git:
  - Sets core.excludesfile to ~/.gitignore_global

- Update README.md with documentation:
  - Add .gitignore_global to Contents section
  - Document global gitignore patterns
  - Update manual setup instructions

Closes #8 
