### PR TITLE
feat: Create and symlink .gitignore_global file

### DIFF
--- a/.gitignore_global
+++ b/.gitignore_global
@@ -1,0 +1,288 @@
+# Global .gitignore patterns for common IDEs, OS files, and development tools
+# This file is meant to be used with: git config --global core.excludesfile ~/.gitignore_global
+
+# ============================================================================
+# IDE and Editor Files
+# ============================================================================
+
+# VS Code
+.vscode/
+*.code-workspace
+.VSCodeCounter/
+
+# JetBrains IDEs (IntelliJ, PyCharm, WebStorm, etc.)
+.idea/
+*.iml
+*.iws
+*.ipr
+*.swp
+*.swo
+*~
+
+# Vim
+.vim/
+*.vim
+.vimrc
+.netrwhist
+*~
+*.swp
+*.swo
+
+# Sublime Text
+*.sublime-project
+*.sublime-workspace
+
+# Emacs
+*~
+\#*\#
+.\#*
+
+# Atom
+.atom/
+
+# Eclipse
+.classpath
+.project
+.settings/
+.vscode/
+
+# Notepad++
+*.bak
+
+# ============================================================================
+# OS-Specific Files
+# ============================================================================
+
+# macOS
+.DS_Store
+.AppleDouble
+.LSOverride
+.Spotlight-V100
+.Trashes
+.VolumeIcon.icns
+.TemporaryItems
+*.swp
+*~.nib
+
+# Windows
+Thumbs.db
+ehthumbs.db
+Desktop.ini
+$RECYCLE.BIN/
+*.lnk
+*.exe
+*.bat
+*.cmd
+*.com
+
+# Linux
+.directory
+
+# ============================================================================
+# Python
+# ============================================================================
+
+__pycache__/
+*.py[cod]
+*$py.class
+*.so
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+pip-wheel-metadata/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+.pytest_cache/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.tox/
+.nox/
+.pylint.d/
+.mypy_cache/
+.dmypy.json
+dmypy.json
+.pyre/
+venv/
+ENV/
+env/
+.venv
+*.pyo
+
+# ============================================================================
+# Node.js / npm
+# ============================================================================
+
+node_modules/
+npm-debug.log
+npm-debug.log.*
+yarn-debug.log
+yarn-error.log
+.npm
+package-lock.json
+yarn.lock
+
+# ============================================================================
+# Ruby / Bundler
+# ============================================================================
+
+Gemfile.lock
+.bundle/
+vendor/bundle/
+
+# ============================================================================
+# Go
+# ============================================================================
+
+*.o
+*.a
+*.so
+*.dylib
+*.test
+*.out
+/dist/
+
+# ============================================================================
+# Java
+# ============================================================================
+
+*.class
+*.jar
+*.war
+*.ear
+.classpath
+.project
+.gradle/
+build/
+*.log
+
+# ============================================================================
+# C / C++
+# ============================================================================
+
+*.o
+*.a
+*.so
+*.dylib
+*.exe
+*.out
+*.app
+
+# ============================================================================
+# Build and Compilation Outputs
+# ============================================================================
+
+bin/
+obj/
+build/
+dist/
+target/
+out/
+.gradle
+*.log
+*.out
+*.tmp
+*.swp
+
+# ============================================================================
+# Dependency Management
+# ============================================================================
+
+vendor/
+node_modules/
+.bundle/
+*.lock
+Gemfile.lock
+
+# ============================================================================
+# Local Configuration Files
+# ============================================================================
+
+.env
+.env.local
+.env.*.local
+.secrets
+config/local/
+local_config.yaml
+private.key
+*.pem
+*.key
+credentials.json
+oauth_token
+.aws/credentials
+.ssh/
+.pgpass
+
+# ============================================================================
+# Temporary and Cache Files
+# ============================================================================
+
+*.tmp
+*.temp
+*.cache
+.cache/
+*.bak
+*.backup
+*.orig
+*.swp
+*.swo
+*~
+.DS_Store
+Thumbs.db
+.directory
+
+# ============================================================================
+# IDE-Specific Project Files
+# ============================================================================
+
+.classpath
+.project
+.factorypath
+.sts4-cache/
+.springBeans
+.sts4-cache
+
+# ============================================================================
+# Testing
+# ============================================================================
+
+.coverage
+.coverage.*
+htmlcov/
+.tox/
+.hypothesis/
+.pytest_cache/
+
+# ============================================================================
+# Documentation
+# ============================================================================
+
+site/
+docs/_build/
+dist/
+
+# ============================================================================
+# Misc
+# ============================================================================
+
+*.md.swp
+.vimrc.custom
+Session.vim

--- a/scripts/Setup-GitConfig.ps1
+++ b/scripts/Setup-GitConfig.ps1
@@ -183,9 +183,31 @@ else {
 
 Write-Host ""
 
-# STEP 3: Create Scheduled Task
+# STEP 3: Configure Global Gitignore
+Write-Host "[STEP 3] Configuring global gitignore..." -ForegroundColor Cyan
+Write-Host "-----" -ForegroundColor Cyan
+
+$gitignoreGlobalPath = "$homeDir\.gitignore_global"
+if (Test-Path $gitignoreGlobalPath) {
+    try {
+        # Convert path to forward slashes for git config
+        $gitignoreGlobalForward = $gitignoreGlobalPath -replace '\\', '/'
+        & git config --global core.excludesfile $gitignoreGlobalForward
+        Write-Host "[OK] Configured global excludesfile" -ForegroundColor Green
+    }
+    catch {
+        Write-Host "[FAIL] Could not configure global excludesfile" -ForegroundColor Red
+    }
+}
+else {
+    Write-Host "[WARN] .gitignore_global symlink not found" -ForegroundColor Yellow
+}
+
+Write-Host ""
+
+# STEP 4: Create Scheduled Task
 if (-not $NoTask) {
-    Write-Host "[STEP 3] Setting up scheduled task..." -ForegroundColor Cyan
+    Write-Host "[STEP 4] Setting up scheduled task..." -ForegroundColor Cyan
     Write-Host "-----" -ForegroundColor Cyan
 
     $taskName = "GitConfig Pull at Login"
@@ -235,8 +257,8 @@ if (-not $NoTask) {
     Write-Host ""
 }
 
-# STEP 4: Verify Setup
-Write-Host "[STEP 4] Verifying setup..." -ForegroundColor Cyan
+# STEP 5: Verify Setup
+Write-Host "[STEP 5] Verifying setup..." -ForegroundColor Cyan
 Write-Host "-----" -ForegroundColor Cyan
 
 foreach ($item in $filesToLink) {


### PR DESCRIPTION
- Create comprehensive .gitignore_global with patterns for:
  - IDEs (VS Code, JetBrains, Vim, Sublime, Emacs, Atom)
  - OS-specific files (macOS, Windows, Linux)
  - Language artifacts (Python, Node.js, Go, Java, Ruby, C/C++)
  - Build outputs and temporary files
  - Local configuration and credentials

- Update Initialize-Symlinks.ps1 to symlink .gitignore_global
- Update Setup-GitConfig.ps1 to include .gitignore_global in setup
  - Add [core] section with excludesfile configuration

- Update Initialize-LocalConfig.ps1 to configure git:
  - Sets core.excludesfile to ~/.gitignore_global

- Update README.md with documentation:
  - Add .gitignore_global to Contents section
  - Document global gitignore patterns
  - Update manual setup instructions

Closes #8