### PR TITLE
chore: remove tracked build/test artifacts

### DIFF
--- a/test_output.txt
+++ b/test_output.txt
@@ -1,2 +1,0 @@
-ERROR: Invalid syntax. Default option is not allowed more than '1' time(s).
-Type "TIMEOUT /?" for usage.


### PR DESCRIPTION
Fixes #44

- Adds `test_output.txt` to `.gitignore` and removes it from tracking
- `docs/update-gitconfig.log` was already gitignored; consolidates the comment