### PR TITLE
fix: Correct Windows script path computation

### DIFF
--- a/scripts/windows version/Initialize-GitConfig.ps1
+++ b/scripts/windows version/Initialize-GitConfig.ps1
@@ -38,7 +38,8 @@ TEMPLATE PLACEHOLDERS:
 }
 
 # Get paths
-$repoRoot = Split-Path -Parent (Split-Path -Parent $MyInvocation.MyCommand.Path)
+$scriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+$repoRoot  = Split-Path -Parent (Split-Path -Parent $scriptDir)
 $homeDir = $env:USERPROFILE
 if (-not $homeDir) {
     $homeDir = $env:HOME  # Unix/Linux fallback

--- a/scripts/windows version/Initialize-Symlinks.ps1
+++ b/scripts/windows version/Initialize-Symlinks.ps1
@@ -54,8 +54,9 @@ if (-not $isAdmin) {
     Write-Host ""
 }
 
-# Get the repository root (parent of scripts directory)
-$repoRoot = Split-Path -Parent (Split-Path -Parent $MyInvocation.MyCommand.Path)
+# Get the repository root (two levels up from scripts\windows version\)
+$scriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+$repoRoot  = Split-Path -Parent (Split-Path -Parent $scriptDir)
 $homeDir = $env:USERPROFILE
 
 Write-Host "Dotfiles Setup" -ForegroundColor Cyan

--- a/scripts/windows version/Register-LoginTask.ps1
+++ b/scripts/windows version/Register-LoginTask.ps1
@@ -2,9 +2,14 @@
 # This script creates a scheduled task to run Update-GitConfig.ps1 when the user logs in
 
 param(
-    [string]$ScriptPath = "$env:USERPROFILE\Documents\Scripts\gitconfig\scripts\Update-GitConfig.ps1",
+    [string]$ScriptPath = "",
     [switch]$Force
 )
+
+if (-not $ScriptPath) {
+    $scriptDir  = Split-Path -Parent $MyInvocation.MyCommand.Path
+    $ScriptPath = Join-Path $scriptDir "Update-GitConfig.ps1"
+}
 
 # Task configuration
 $taskName = "GitConfig Pull at Login"

--- a/scripts/windows version/Setup-GitConfig.ps1
+++ b/scripts/windows version/Setup-GitConfig.ps1
@@ -58,9 +58,10 @@ if (-not $isAdmin) {
     }
 }
 
-$repoRoot    = Split-Path -Parent (Split-Path -Parent $MyInvocation.MyCommand.Path)
+$scriptDir   = Split-Path -Parent $MyInvocation.MyCommand.Path
+$repoRoot    = Split-Path -Parent (Split-Path -Parent $scriptDir)
 $homeDir     = $env:USERPROFILE
-$scriptsDir  = Join-Path $repoRoot "scripts\windows version"
+$scriptsDir  = $scriptDir
 $cleanupScript     = Join-Path $scriptsDir "Cleanup-GitConfig.ps1"
 $initGitScript     = Join-Path $scriptsDir "Initialize-GitConfig.ps1"
 $initLocalScript   = Join-Path $scriptsDir "Initialize-LocalConfig.ps1"


### PR DESCRIPTION
Fixes #53

The four Windows PS1 scripts were computing repo root with two `Split-Path -Parent` calls applied directly to `$MyInvocation.MyCommand.Path`. Since the scripts live at `scripts\windows version\<script>.ps1`, two levels up from the full path yields `scripts\` — not the repo root. A third `Split-Path -Parent` is needed.

**Changes:**
- `Setup-GitConfig.ps1`: introduce `$scriptDir`, compute `$repoRoot` three levels up, assign `$scriptsDir = $scriptDir` (eliminates the doubled `scripts\scripts\windows version\` path)
- `Initialize-GitConfig.ps1`: same `$scriptDir` + three-level fix
- `Initialize-Symlinks.ps1`: same `$scriptDir` + three-level fix
- `Register-LoginTask.ps1`: replace hardcoded `$env:USERPROFILE\Documents\Scripts\gitconfig\scripts\Update-GitConfig.ps1` default with dynamic resolution via `$scriptDir`