### PR TITLE
fix: pull main after fetch in cleanup_branches()

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,8 @@
 # Generated git configuration (created from .gitconfig.template)
 .gitconfig
 
-# Update GitConfig logs
+# Test output and logs
+test_output.txt
 docs/update-gitconfig.log
 
 # Claude Code local session data

--- a/gitconfig_helper.py
+++ b/gitconfig_helper.py
@@ -76,6 +76,12 @@ def cleanup_branches(force=False):
         console.print("[cyan]Running git cleanup...[/cyan]")
         run_git("fetch", "-p")
 
+        # Pull latest changes on main so local doesn't fall behind after cleanup
+        console.print("[cyan]Pulling latest changes on main...[/cyan]")
+        pull_result = run_git("pull")
+        if pull_result.returncode != 0:
+            console.print(f"[yellow]Warning: git pull failed: {pull_result.stderr.strip()}[/yellow]")
+
         # Get list of branches to delete:
         # 1. Branches with no remote tracking (no [origin/...] in output) - requires confirmation
         # 2. Branches where the remote has been deleted (contains ": gone]") - auto-delete


### PR DESCRIPTION
Fixes #56

`cleanup_branches()` called `git fetch -p` but never `git pull`, so running `git cleanup` directly left local main behind origin. Added a pull immediately after the fetch while still on main.

`switch_to_main()` was unaffected since it pulls before delegating to `cleanup_branches()`.