### PR TITLE
fix: add test_output.txt to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,8 @@
 # Generated git configuration (created from .gitconfig.template)
 .gitconfig
 
-# Update GitConfig logs
+# Test output and logs
+test_output.txt
 docs/update-gitconfig.log
 
 # Claude Code local session data


### PR DESCRIPTION
Fixes #55

The commit from #44 ran `git rm --cached test_output.txt` to untrack the file but never committed the corresponding `.gitignore` entry. This completes that work.