### PR TITLE
refactor: rename Setup-GitConfig.ps1 to install.ps1

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,7 +28,7 @@ This repo targets **macOS, Linux, and Windows** — it's a cross-platform dotfil
 | File | Purpose |
 |------|---------|
 | `gitconfig_helper.py` | Cross-platform helper — Python 3 |
-| `scripts/windows version/Setup-GitConfig.ps1` | Windows setup entrypoint |
+| `scripts/windows version/install.ps1` | Windows setup entrypoint |
 | `scripts/shared/` | Shared bash library and scripts (mac + linux) |
 | `scripts/mac version/` | macOS bash entry points |
 | `scripts/linux version/` | Linux bash entry points |

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ bash scripts/mac\ version/setup-gitconfig.sh --force
 ```powershell
 git clone https://github.com/J-MaFf/gitconfig.git ~/Documents/Scripts/gitconfig
 cd ~/Documents/Scripts/gitconfig
-.\scripts\Setup-GitConfig.ps1 -Force
+.\scripts\install.ps1 -Force
 python -m pip install rich
 ```
 
@@ -62,8 +62,8 @@ git main           # Switch to main with fetch, pull, and branch cleanup
 ### Setup Script Options (Windows)
 
 ```powershell
-.\scripts\Setup-GitConfig.ps1 -Force           # Full setup
-.\scripts\Setup-GitConfig.ps1 -Force -NoTask   # Skip scheduled task
+.\scripts\install.ps1 -Force           # Full setup
+.\scripts\install.ps1 -Force -NoTask   # Skip scheduled task
 .\scripts\Initialize-GitConfig.ps1 -Force      # Regenerate .gitconfig from template
 .\scripts\Initialize-Symlinks.ps1 -Force       # Recreate symlinks
 .\scripts\Initialize-LocalConfig.ps1 -Force    # Regenerate local config

--- a/config/pester.config.ps1
+++ b/config/pester.config.ps1
@@ -14,7 +14,7 @@ $PesterConfig = @{
     CodeCoverage = @{
         Enabled = $true
         Path    = @(
-            './scripts/Setup-GitConfig.ps1',
+            './scripts/install.ps1',
             './scripts/Cleanup-GitConfig.ps1'
         )
     }

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -23,7 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Formatted console output using Rich library
 
 - **Setup Automation (PowerShell Scripts)**
-  - `Setup-GitConfig.ps1` - Unified setup wrapper orchestrating complete configuration
+  - `install.ps1` - Unified setup wrapper orchestrating complete configuration
   - `Initialize-Symlinks.ps1` - Create symbolic links from home directory to repo files
   - `Initialize-LocalConfig.ps1` - Generate machine-specific `.gitconfig.local`
   - `Register-LoginTask.ps1` - Create Windows scheduled task for auto-sync
@@ -99,9 +99,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Breaking Changes
 
 - **BREAKING**: `.gitconfig` is now generated from `.gitconfig.template` instead of being version controlled
-  - Existing setup will require running `Setup-GitConfig.ps1` again to regenerate
+  - Existing setup will require running `install.ps1` again to regenerate
   - Benefits: No hardcoded paths, complete portability across machines
-- Updated `Setup-GitConfig.ps1` to generate config instead of creating symlink
+- Updated `install.ps1` to generate config instead of creating symlink
 - `.gitconfig` is no longer a symlink - it's a generated file in home directory
 - Only `.gitignore_global` and `gitconfig_helper.py` are symlinked now
 

--- a/docs/WORKFLOW.md
+++ b/docs/WORKFLOW.md
@@ -618,7 +618,7 @@ cmd /c dir "$env:USERPROFILE\gitconfig_helper.py" /L
 ```powershell
 # Run setup script
 cd ~\Documents\Scripts\gitconfig
-.\scripts\Setup-GitConfig.ps1 -Force
+.\scripts\install.ps1 -Force
 ```
 
 ---
@@ -637,7 +637,7 @@ git config --get-all alias.alias
 Get-Command gitconfig_helper.py
 
 # Re-run setup
-.\scripts\Setup-GitConfig.ps1 -Force
+.\scripts\install.ps1 -Force
 ```
 
 ---
@@ -674,7 +674,7 @@ Get-Content "~\Documents\Scripts\gitconfig\docs\pull-daily.log" -Tail 10
 
 ```powershell
 .\scripts\Cleanup-GitConfig.ps1 -Force
-.\scripts\Setup-GitConfig.ps1 -Force
+.\scripts\install.ps1 -Force
 ```
 
 ---
@@ -696,7 +696,7 @@ python "~\Documents\Scripts\gitconfig\gitconfig_helper.py"
 pip install --upgrade rich
 
 # Re-run setup
-.\scripts\Setup-GitConfig.ps1 -Force
+.\scripts\install.ps1 -Force
 ```
 
 ---
@@ -712,7 +712,7 @@ The setup scripts automatically request admin elevation. If you still get permis
 ```powershell
 # Run PowerShell as Administrator
 # Then run setup again
-.\scripts\Setup-GitConfig.ps1 -Force
+.\scripts\install.ps1 -Force
 ```
 
 ---
@@ -778,7 +778,7 @@ Get-Content "~\Documents\Scripts\gitconfig\docs\pull-daily.log" -Tail 5
 **If something fails** ❌ - Run the setup script:
 
 ```powershell
-.\scripts\Setup-GitConfig.ps1 -Force
+.\scripts\install.ps1 -Force
 ```
 
 ---

--- a/scripts/windows version/Cleanup-GitConfig.ps1
+++ b/scripts/windows version/Cleanup-GitConfig.ps1
@@ -227,7 +227,7 @@ if ($verifyErrors -eq 0) {
     Write-Host "All gitconfig-related files and tasks removed." -ForegroundColor Green
     Write-Host ""
     Write-Host "Ready to test fresh setup:" -ForegroundColor Cyan
-    Write-Host "  .\Setup-GitConfig.ps1 -Force" -ForegroundColor Cyan
+    Write-Host "  .\install.ps1 -Force" -ForegroundColor Cyan
 }
 else {
     Write-Host "Cleanup INCOMPLETE - $verifyErrors items still present" -ForegroundColor Red

--- a/scripts/windows version/install.ps1
+++ b/scripts/windows version/install.ps1
@@ -12,7 +12,7 @@ if ($Help) {
     Write-Host @"
 GitConfig Setup Wrapper
 
-USAGE: .\Setup-GitConfig.ps1 [OPTIONS]
+USAGE: .\install.ps1 [OPTIONS]
 
 OPTIONS:
     -Force      Overwrite existing files without prompting

--- a/tests/Integration.Tests.ps1
+++ b/tests/Integration.Tests.ps1
@@ -1,6 +1,6 @@
 BeforeAll {
     $script:repoRoot = Split-Path -Parent $PSScriptRoot
-    $script:setupScript = Join-Path $script:repoRoot "scripts\Setup-GitConfig.ps1"
+    $script:setupScript = Join-Path $script:repoRoot "scripts\install.ps1"
     $script:cleanupScript = Join-Path $script:repoRoot "scripts\Cleanup-GitConfig.ps1"
     $script:testHome = $env:USERPROFILE
     if (-not $script:testHome) {
@@ -25,7 +25,7 @@ Describe "GitConfig Integration" {
         It "Should complete setup without errors" -Skip:((-not [System.Environment]::UserInteractive) -or (-not $script:platformIsWindows)) {
             # This test is skipped in non-interactive environments (Pester extension)
             # Also skipped on non-Windows platforms as the scripts are Windows-specific
-            # Run manually on command line: .\Setup-GitConfig.ps1 -Force
+            # Run manually on command line: .\install.ps1 -Force
             & $script:pwshExe -NoProfile -ExecutionPolicy Bypass -File $script:setupScript -Force 2>&1 | Out-Null
             $LASTEXITCODE | Should -Be 0
         }

--- a/tests/Setup-GitConfig.Tests.ps1
+++ b/tests/Setup-GitConfig.Tests.ps1
@@ -1,7 +1,7 @@
 BeforeAll {
     # Setup variables
     $script:repoRoot = Split-Path -Parent $PSScriptRoot
-    $script:scriptPath = Join-Path $script:repoRoot "scripts\Setup-GitConfig.ps1"
+    $script:scriptPath = Join-Path $script:repoRoot "scripts\install.ps1"
     $script:testHome = $env:USERPROFILE
     if (-not $script:testHome) {
         $script:testHome = $env:HOME  # Unix/Linux fallback
@@ -31,12 +31,12 @@ BeforeAll {
 
     # Run setup if in interactive mode
     if ($script:isAdmin -and [System.Environment]::UserInteractive) {
-        Write-Host "Running Setup-GitConfig.ps1 for testing..." -ForegroundColor Cyan
+        Write-Host "Running install.ps1 for testing..." -ForegroundColor Cyan
         & $script:scriptPath -Force -ErrorAction SilentlyContinue | Out-Null
     }
 }
 
-Describe "Setup-GitConfig.ps1" {
+Describe "install.ps1" {
 
     Context "Script Parameters" {
         It "Should accept -Force parameter" {
@@ -183,7 +183,7 @@ Describe "Setup-GitConfig.ps1" {
     Context "Scheduled Task Creation" {
         It "Should create Update-GitConfig scheduled task" -Skip:(-not $script:platformIsWindows) {
             # Note: This test is skipped when setup runs with -NoTask (which it does for testing)
-            # To fully test task creation, run Setup-GitConfig.ps1 -Force (without -NoTask)
+            # To fully test task creation, run install.ps1 -Force (without -NoTask)
             # Scheduled tasks are Windows-only
             $task = Get-ScheduledTask -TaskName "Update-GitConfig" -ErrorAction SilentlyContinue
             if ($task) {


### PR DESCRIPTION
Fixes #61

## Changes
- Rename `scripts/windows version/Setup-GitConfig.ps1` → `install.ps1`
- Update USAGE comment inside the script
- Update README.md, CLAUDE.md, WORKFLOW.md, CHANGELOG.md
- Update all test files (path references, describe block label, comments)
- Update `config/pester.config.ps1` code-coverage path
- Update `Cleanup-GitConfig.ps1` help text