### PR TITLE
refactor: rename setup-gitconfig.sh to install.sh (mac + linux)

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Personal Git configuration and utilities for cross-machine synchronization.
 ```bash
 git clone https://github.com/J-MaFf/gitconfig.git ~/Documents/Scripts/gitconfig
 cd ~/Documents/Scripts/gitconfig
-bash scripts/mac\ version/setup-gitconfig.sh --force
+bash scripts/mac\ version/install.sh --force
 pip3 install rich
 ```
 
@@ -21,7 +21,7 @@ pip3 install rich
 
 ```bash
 brew install 1password-cli
-bash scripts/mac\ version/setup-gitconfig.sh --force
+bash scripts/mac\ version/install.sh --force
 ```
 
 ### Windows (PowerShell)
@@ -42,7 +42,7 @@ python -m pip install rich
 ```bash
 git clone https://github.com/J-MaFf/gitconfig.git ~/Documents/Scripts/gitconfig
 cd ~/Documents/Scripts/gitconfig
-bash scripts/linux\ version/setup-gitconfig.sh --force
+bash scripts/linux\ version/install.sh --force
 pip install rich
 ```
 

--- a/scripts/linux version/README.md
+++ b/scripts/linux version/README.md
@@ -16,7 +16,7 @@ This directory provides a complete Linux/Unix version of the gitconfig setup sys
 
 ### Main Scripts
 
-- **setup-gitconfig.sh** - Main setup wrapper orchestrates complete installation
+- **install.sh** - Main setup wrapper orchestrates complete installation
   - Cleans previous installation
   - Generates .gitconfig from template
   - Creates symlinks
@@ -60,18 +60,18 @@ chmod +x *.sh
 Run the main setup script:
 
 ```bash
-./setup-gitconfig.sh
+./install.sh
 ```
 
 ### Options
 
-**setup-gitconfig.sh**
+**install.sh**
 
 ```bash
-./setup-gitconfig.sh                # Interactive mode
-./setup-gitconfig.sh --force        # Overwrite without prompting
-./setup-gitconfig.sh --no-cron      # Skip cron job setup
-./setup-gitconfig.sh --help         # Show help
+./install.sh                # Interactive mode
+./install.sh --force        # Overwrite without prompting
+./install.sh --no-cron      # Skip cron job setup
+./install.sh --help         # Show help
 ```
 
 **cleanup-gitconfig.sh**
@@ -112,13 +112,13 @@ Run the main setup script:
 1. **Execution** - Make scripts executable
 
    ```bash
-   chmod +x setup-gitconfig.sh cleanup-gitconfig.sh
+   chmod +x install.sh cleanup-gitconfig.sh
    ```
 
 2. **Run Setup** - Execute main setup script
 
    ```bash
-   ./setup-gitconfig.sh
+   ./install.sh
    ```
 
 3. **Verify** - Check that symlinks and config are in place
@@ -207,7 +207,7 @@ All files are backed up to `~/*.bak` before removal.
 
 ### Custom Cron Schedule
 
-Edit the cron entry in `setup-gitconfig.sh` before running:
+Edit the cron entry in `install.sh` before running:
 
 ```bash
 # Change this line:
@@ -237,7 +237,7 @@ To test the setup without making permanent changes:
 
 ```bash
 # Setup in test mode
-./setup-gitconfig.sh --force
+./install.sh --force
 
 # Verify
 git config --list

--- a/scripts/linux version/cleanup-gitconfig.sh
+++ b/scripts/linux version/cleanup-gitconfig.sh
@@ -103,7 +103,7 @@ if [ $ERRORS -eq 0 ]; then
     echo "Cleanup SUCCESSFUL!"
     echo ""
     echo "Ready to test fresh setup:"
-    echo "  bash $SCRIPT_DIR/setup-gitconfig.sh --force"
+    echo "  bash $SCRIPT_DIR/install.sh --force"
 else
     echo "Cleanup INCOMPLETE - $ERRORS items still present"
 fi

--- a/scripts/linux version/install.sh
+++ b/scripts/linux version/install.sh
@@ -25,7 +25,7 @@ if [ "$HELP" = true ]; then
     cat << 'EOF'
 GitConfig Setup Wrapper - Linux/Unix Version
 
-USAGE: ./setup-gitconfig.sh [OPTIONS]
+USAGE: ./install.sh [OPTIONS]
 
 OPTIONS:
     -f, --force     Overwrite existing files without prompting

--- a/scripts/mac version/cleanup-gitconfig.sh
+++ b/scripts/mac version/cleanup-gitconfig.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # GitConfig Cleanup Script - macOS Version
-# Removes symlinks, config files, and launchd agent created by setup-gitconfig.sh.
+# Removes symlinks, config files, and launchd agent created by install.sh.
 
 set -e
 
@@ -107,7 +107,7 @@ if [ $ERRORS -eq 0 ]; then
     echo "Cleanup SUCCESSFUL!"
     echo ""
     echo "To reinstall, run:"
-    echo "  bash $SCRIPT_DIR/setup-gitconfig.sh --force"
+    echo "  bash $SCRIPT_DIR/install.sh --force"
 else
     echo "Cleanup INCOMPLETE — $ERRORS items still present"
 fi

--- a/scripts/mac version/install.sh
+++ b/scripts/mac version/install.sh
@@ -26,7 +26,7 @@ if [ "$HELP" = true ]; then
     cat << 'EOF'
 GitConfig Setup Wrapper - macOS Version
 
-USAGE: ./setup-gitconfig.sh [OPTIONS]
+USAGE: ./install.sh [OPTIONS]
 
 OPTIONS:
     -f, --force       Overwrite existing files without prompting


### PR DESCRIPTION
Fixes #63

Follow-up to #62 (Windows rename). Renames the macOS and Linux setup entrypoints to `install.sh` for consistency.

## Changes
- Rename `scripts/mac version/setup-gitconfig.sh` → `install.sh`
- Rename `scripts/linux version/setup-gitconfig.sh` → `install.sh`
- Update USAGE comments inside each script
- Update README.md mac and linux install instructions
- Update `cleanup-gitconfig.sh` help text (mac + linux)
- Update `scripts/linux version/README.md`