### PR TITLE
feat: auto-install Python rich dependency in install.ps1 (Windows)

### DIFF
--- a/scripts/windows version/install.ps1
+++ b/scripts/windows version/install.ps1
@@ -153,8 +153,40 @@ if (-not $NoTask) {
     Write-Host ""
 }
 
-# STEP 6: Verify setup
-Write-Host "[STEP 6] Verifying setup..." -ForegroundColor Cyan
+# STEP 6: Install Python dependencies
+Write-Host "[STEP 6] Installing Python dependencies..." -ForegroundColor Cyan
+Write-Host "-----" -ForegroundColor Cyan
+$pip = Get-Command pip -ErrorAction SilentlyContinue
+$pip3 = Get-Command pip3 -ErrorAction SilentlyContinue
+$pipCmd = if ($pip3) { "pip3" } elseif ($pip) { "pip" } else { $null }
+
+if ($pipCmd) {
+    $richCheck = & $pipCmd show rich 2>$null
+    if ($richCheck) {
+        Write-Host "[OK] Python 'rich' already installed" -ForegroundColor Green
+    }
+    else {
+        try {
+            & $pipCmd install rich --quiet 2>$null
+            if ($LASTEXITCODE -eq 0) {
+                Write-Host "[OK] Installed Python 'rich'" -ForegroundColor Green
+            }
+            else {
+                Write-Host "[WARN] Could not install 'rich' — run manually: pip install rich" -ForegroundColor Yellow
+            }
+        }
+        catch {
+            Write-Host "[WARN] Could not install 'rich' — run manually: pip install rich" -ForegroundColor Yellow
+        }
+    }
+}
+else {
+    Write-Host "[WARN] pip not found — install Python 3 from https://python.org" -ForegroundColor Yellow
+}
+Write-Host ""
+
+# STEP 7: Verify setup
+Write-Host "[STEP 7] Verifying setup..." -ForegroundColor Cyan
 Write-Host "-----" -ForegroundColor Cyan
 
 $verifyFiles = @(".gitconfig", ".gitignore_global", "gitconfig_helper.py", ".gitconfig.local")
@@ -162,6 +194,15 @@ foreach ($file in $verifyFiles) {
     $path = Join-Path $homeDir $file
     if (Test-Path $path) { Write-Host "[OK] $file verified" -ForegroundColor Green }
     else                  { Write-Host "[FAIL] $file missing" -ForegroundColor Red }
+}
+
+try {
+    $richImport = & python -c "import rich" 2>$null
+    if ($LASTEXITCODE -eq 0) { Write-Host "[OK] Python 'rich' importable" -ForegroundColor Green }
+    else                     { Write-Host "[WARN] Python 'rich' not importable" -ForegroundColor Yellow }
+}
+catch {
+    Write-Host "[WARN] Could not verify Python 'rich'" -ForegroundColor Yellow
 }
 
 try {

--- a/scripts/windows version/install.ps1
+++ b/scripts/windows version/install.ps1
@@ -196,13 +196,23 @@ foreach ($file in $verifyFiles) {
     else                  { Write-Host "[FAIL] $file missing" -ForegroundColor Red }
 }
 
-try {
-    $richImport = & python -c "import rich" 2>$null
-    if ($LASTEXITCODE -eq 0) { Write-Host "[OK] Python 'rich' importable" -ForegroundColor Green }
-    else                     { Write-Host "[WARN] Python 'rich' not importable" -ForegroundColor Yellow }
+$pyCmd = if (Get-Command py -ErrorAction SilentlyContinue)      { "py" }
+         elseif (Get-Command python3 -ErrorAction SilentlyContinue) { "python3" }
+         elseif (Get-Command python -ErrorAction SilentlyContinue)  { "python" }
+         else { $null }
+
+if ($pyCmd) {
+    try {
+        & $pyCmd -c "import rich" 2>$null
+        if ($LASTEXITCODE -eq 0) { Write-Host "[OK] Python 'rich' importable" -ForegroundColor Green }
+        else                     { Write-Host "[WARN] Python 'rich' not importable" -ForegroundColor Yellow }
+    }
+    catch {
+        Write-Host "[WARN] Could not verify Python 'rich'" -ForegroundColor Yellow
+    }
 }
-catch {
-    Write-Host "[WARN] Could not verify Python 'rich'" -ForegroundColor Yellow
+else {
+    Write-Host "[WARN] Python not found — cannot verify 'rich'" -ForegroundColor Yellow
 }
 
 try {

--- a/tests/Setup-GitConfig.Tests.ps1
+++ b/tests/Setup-GitConfig.Tests.ps1
@@ -55,6 +55,23 @@ Describe "install.ps1" {
         }
     }
 
+    Context "Python Dependencies" {
+        It "Should attempt to install Python rich library" {
+            $scriptContent = Get-Content $script:scriptPath -Raw
+            $scriptContent | Should -Match "pip.*install.*rich"
+        }
+
+        It "Should verify rich is importable" {
+            $scriptContent = Get-Content $script:scriptPath -Raw
+            $scriptContent | Should -Match "import rich"
+        }
+
+        It "Should warn gracefully if pip is not available" {
+            $scriptContent = Get-Content $script:scriptPath -Raw
+            $scriptContent | Should -Match "\[WARN\].*pip"
+        }
+    }
+
     Context "Config Generation" {
         It "Should generate .gitconfig in home directory" -Skip:((-not [System.Environment]::UserInteractive) -or (-not $script:platformIsWindows)) {
             $gitconfigPath = Join-Path $script:testHome ".gitconfig"


### PR DESCRIPTION
Fixes #67

Adds STEP 6 to `scripts/windows version/install.ps1` that auto-installs the `rich` Python library, matching the behavior already present in the macOS and Linux `install.sh` scripts (added in #66).

## Changes

- Detects `pip3` or `pip`, whichever is available
- Skips install if `rich` is already present (`pip show rich`)
- Installs `rich --quiet` and reports success/failure
- Warns gracefully if pip is not found (links to python.org)
- Renumbers the old STEP 6 (verify) to STEP 7
- Adds `python -c "import rich"` check to the verify step
- Adds three Pester unit tests for the new pip behavior