### PR TITLE
docs: add uninstall instructions and clean up README

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ bash scripts/mac\ version/install.sh --force
 ```powershell
 git clone https://github.com/J-MaFf/gitconfig.git ~/Documents/Scripts/gitconfig
 cd ~/Documents/Scripts/gitconfig
-.\scripts\windows` version\install.ps1 -Force
+& ".\scripts\windows version\install.ps1" -Force
 ```
 
 ### Linux
@@ -60,7 +60,7 @@ Removes: `~/.gitconfig`, `~/.gitignore_global` symlink, `~/gitconfig_helper.py` 
 ### Windows (PowerShell)
 
 ```powershell
-.\scripts\windows` version\Cleanup-GitConfig.ps1
+& ".\scripts\windows version\Cleanup-GitConfig.ps1"
 ```
 
 Removes: `~/.gitconfig`, symlinks, `~/.gitconfig.local`, and the `Update-GitConfig` scheduled task.
@@ -87,11 +87,11 @@ git main           # Switch to main with fetch, pull, and branch cleanup
 ### Setup Script Options (Windows)
 
 ```powershell
-.\scripts\windows` version\install.ps1 -Force           # Full setup
-.\scripts\windows` version\install.ps1 -Force -NoTask   # Skip scheduled task
-.\scripts\windows` version\Initialize-GitConfig.ps1 -Force      # Regenerate .gitconfig from template
-.\scripts\windows` version\Initialize-Symlinks.ps1 -Force       # Recreate symlinks
-.\scripts\windows` version\Initialize-LocalConfig.ps1 -Force    # Regenerate local config
+& ".\scripts\windows version\install.ps1" -Force           # Full setup
+& ".\scripts\windows version\install.ps1" -Force -NoTask   # Skip scheduled task
+& ".\scripts\windows version\Initialize-GitConfig.ps1" -Force      # Regenerate .gitconfig from template
+& ".\scripts\windows version\Initialize-Symlinks.ps1" -Force       # Recreate symlinks
+& ".\scripts\windows version\Initialize-LocalConfig.ps1" -Force    # Regenerate local config
 ```
 
 ## Contents

--- a/README.md
+++ b/README.md
@@ -14,7 +14,6 @@ Personal Git configuration and utilities for cross-machine synchronization.
 git clone https://github.com/J-MaFf/gitconfig.git ~/Documents/Scripts/gitconfig
 cd ~/Documents/Scripts/gitconfig
 bash scripts/mac\ version/install.sh --force
-pip3 install rich
 ```
 
 *(Optional)* Enable SSH commit signing with 1Password:
@@ -26,13 +25,12 @@ bash scripts/mac\ version/install.sh --force
 
 ### Windows (PowerShell)
 
-**Requirements:** PowerShell 5.1+, Administrator privileges
+**Requirements:** PowerShell 5.1+, Administrator privileges, Python 3
 
 ```powershell
 git clone https://github.com/J-MaFf/gitconfig.git ~/Documents/Scripts/gitconfig
 cd ~/Documents/Scripts/gitconfig
-.\scripts\install.ps1 -Force
-python -m pip install rich
+.\scripts\windows` version\install.ps1 -Force
 ```
 
 ### Linux
@@ -43,10 +41,37 @@ python -m pip install rich
 git clone https://github.com/J-MaFf/gitconfig.git ~/Documents/Scripts/gitconfig
 cd ~/Documents/Scripts/gitconfig
 bash scripts/linux\ version/install.sh --force
-pip install rich
 ```
 
-The setup script handles generating `~/.gitconfig` from the template, creating symlinks, and registering an auto-update job (launchd on macOS, Task Scheduler on Windows, cron on Linux).
+The setup script handles generating `~/.gitconfig` from the template, creating symlinks, installing the `rich` Python dependency, and registering an auto-update job (launchd on macOS, Task Scheduler on Windows, cron on Linux).
+
+## Uninstall
+
+Each platform has a cleanup script that removes symlinks, local config, and the auto-update job.
+
+### macOS
+
+```bash
+bash scripts/mac\ version/cleanup-gitconfig.sh
+```
+
+Removes: `~/.gitconfig`, `~/.gitignore_global` symlink, `~/gitconfig_helper.py` symlink, `~/.gitconfig.local`, and the launchd login agent.
+
+### Windows (PowerShell)
+
+```powershell
+.\scripts\windows` version\Cleanup-GitConfig.ps1
+```
+
+Removes: `~/.gitconfig`, symlinks, `~/.gitconfig.local`, and the `Update-GitConfig` scheduled task.
+
+### Linux
+
+```bash
+bash scripts/linux\ version/cleanup-gitconfig.sh
+```
+
+Removes: `~/.gitconfig`, `~/.gitignore_global` symlink, `~/gitconfig_helper.py` symlink, `~/.gitconfig.local`, and the cron job.
 
 ## Usage
 
@@ -62,11 +87,11 @@ git main           # Switch to main with fetch, pull, and branch cleanup
 ### Setup Script Options (Windows)
 
 ```powershell
-.\scripts\install.ps1 -Force           # Full setup
-.\scripts\install.ps1 -Force -NoTask   # Skip scheduled task
-.\scripts\Initialize-GitConfig.ps1 -Force      # Regenerate .gitconfig from template
-.\scripts\Initialize-Symlinks.ps1 -Force       # Recreate symlinks
-.\scripts\Initialize-LocalConfig.ps1 -Force    # Regenerate local config
+.\scripts\windows` version\install.ps1 -Force           # Full setup
+.\scripts\windows` version\install.ps1 -Force -NoTask   # Skip scheduled task
+.\scripts\windows` version\Initialize-GitConfig.ps1 -Force      # Regenerate .gitconfig from template
+.\scripts\windows` version\Initialize-Symlinks.ps1 -Force       # Recreate symlinks
+.\scripts\windows` version\Initialize-LocalConfig.ps1 -Force    # Regenerate local config
 ```
 
 ## Contents


### PR DESCRIPTION
Fixes #70

## Changes

**New: Uninstall section**
Added an Uninstall section immediately after the Installation section with per-platform cleanup commands and a plain-English description of what each script removes (symlinks, local config, cron/launchd/scheduled task).

**Cleanup: remove manual pip install steps**
The macOS and Linux install commands had `pip3 install rich` / `pip install rich` as a separate manual step. Since PR #66 added auto-installation to `install.sh`, these are now redundant and removed. Same for Windows (PR #71 added it to `install.ps1`).

**Fix: Windows script paths in Usage section**
The Setup Script Options commands referenced `.\scripts\install.ps1` — missing the `windows version\` subdirectory. Fixed to use the correct paths.