### PR TITLE
feat: self-update reinstalls ~/.gitconfig from template

### DIFF
--- a/.gitconfig.template
+++ b/.gitconfig.template
@@ -33,6 +33,9 @@
     main = !"command -v python3 >/dev/null && python3 {{REPO_PATH}}/gitconfig_helper.py switch_to_main \"$@\" || python {{REPO_PATH}}/gitconfig_helper.py switch_to_main \"$@\""
     # Manage machine-specific git configuration
     localconfig = !git config --file ~/.gitconfig.local
+    # Pull the latest gitconfig repo and reinstall ~/.gitconfig from the template
+    # on demand. Dispatches by OS: Git-for-Windows reports MINGW/MSYS/CYGWIN.
+    selfupdate = "!f() { case \"$(uname -s)\" in MINGW*|MSYS*|CYGWIN*) powershell -NoProfile -File '{{REPO_PATH}}/scripts/windows version/Update-GitConfig.ps1' -RepoPath '{{REPO_PATH}}' ;; *) bash '{{REPO_PATH}}/scripts/shared/update-gitconfig.sh' '{{REPO_PATH}}' ;; esac; }; f"
 
 [init]
 	defaultBranch = main

--- a/README.md
+++ b/README.md
@@ -45,6 +45,8 @@ bash scripts/linux\ version/install.sh --force
 
 The setup script handles generating `~/.gitconfig` from the template, creating symlinks, installing the `rich` Python dependency, and registering an auto-update job (launchd on macOS, Task Scheduler on Windows, cron on Linux).
 
+The auto-update job is **pull + install**: at each login it pulls the latest commits and, if `.gitconfig.template` changed in that pull, regenerates `~/.gitconfig` so template changes take effect without a manual re-run. Your existing `~/.gitconfig` is backed up to `~/.gitconfig.bak` first, and `~/.gitconfig.local` is never modified. Run the same pull-and-install on demand any time with `git selfupdate`.
+
 ## Uninstall
 
 Each platform has a cleanup script that removes symlinks, local config, and the auto-update job.
@@ -83,6 +85,7 @@ git branches       # Track all remote branches
 git cleanup        # Clean up merged local branches
 git main           # Switch to main with fetch, pull, and branch cleanup
 git main --all     # Run the above for every git repo in immediate subdirectories (alias: -a)
+git selfupdate     # Pull this repo and reinstall ~/.gitconfig from the template
 ```
 
 ### Setup Script Options (Windows)

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,22 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- `git selfupdate` alias — pulls the gitconfig repo and reinstalls `~/.gitconfig` from
+  the template on demand, dispatching to the correct platform script
+  (PowerShell on Windows, bash on macOS/Linux) ([#78](https://github.com/J-MaFf/gitconfig/issues/78))
+
+### Fixed
+
+- Login auto-update now reinstalls `~/.gitconfig` when `.gitconfig.template` changed
+  during the pull, instead of only pulling. Template changes (new aliases, signing/push
+  tweaks) take effect automatically with no manual re-run. The existing `~/.gitconfig`
+  is backed up to `~/.gitconfig.bak` first; `~/.gitconfig.local` is never touched
+  ([#78](https://github.com/J-MaFf/gitconfig/issues/78))
+
 ## [0.1.0-pre] - 2025-12-15
 
 ### Added

--- a/scripts/shared/update-gitconfig.sh
+++ b/scripts/shared/update-gitconfig.sh
@@ -4,6 +4,7 @@
 
 REPO_PATH="${1:-$HOME/Documents/Scripts/gitconfig}"
 LOG_FILE="$REPO_PATH/docs/update-gitconfig.log"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 log_message() {
     local timestamp
@@ -32,6 +33,7 @@ mkdir -p "$(dirname "$LOG_FILE")"
     fi
 
     log_message "Pulling latest changes from main..."
+    HEAD_BEFORE=$(git rev-parse HEAD 2>/dev/null)
     PULL_RESULT=$(git pull 2>&1)
     if [ $? -eq 0 ]; then
         log_message "SUCCESS: git pull completed"
@@ -40,6 +42,24 @@ mkdir -p "$(dirname "$LOG_FILE")"
         log_message "ERROR: git pull failed"
         log_message "Output: $PULL_RESULT"
         exit 1
+    fi
+    HEAD_AFTER=$(git rev-parse HEAD 2>/dev/null)
+
+    # Reinstall ~/.gitconfig if the template changed during this pull.
+    # ~/.gitconfig is rendered from .gitconfig.template, so template changes
+    # download on pull but only take effect after regeneration.
+    if [ "$HEAD_BEFORE" != "$HEAD_AFTER" ] && \
+       [ -n "$(git diff --name-only "$HEAD_BEFORE" "$HEAD_AFTER" -- .gitconfig.template)" ]; then
+        log_message ".gitconfig.template changed; regenerating ~/.gitconfig..."
+        # shellcheck source=functions.sh
+        source "$SCRIPT_DIR/functions.sh"
+        if generate_gitconfig "$REPO_PATH" "$HOME" true; then
+            log_message "SUCCESS: ~/.gitconfig regenerated from template (previous saved to ~/.gitconfig.bak)"
+        else
+            log_message "ERROR: Failed to regenerate ~/.gitconfig from template"
+        fi
+    else
+        log_message "No .gitconfig.template changes; skipping regeneration"
     fi
 
     log_message "Synchronizing remote tracking branches..."

--- a/scripts/windows version/Update-GitConfig.ps1
+++ b/scripts/windows version/Update-GitConfig.ps1
@@ -39,6 +39,7 @@ try {
 
     # Step 2: Pull latest changes on main
     Write-Log "Pulling latest changes from main..."
+    $headBefore = (git rev-parse HEAD 2>$null)
     $pullResult = git pull 2>&1
     if ($LASTEXITCODE -eq 0) {
         Write-Log "SUCCESS: git pull completed on main"
@@ -47,6 +48,31 @@ try {
     else {
         Write-Log "ERROR: git pull failed with exit code $LASTEXITCODE"
         Write-Log "Output: $pullResult"
+    }
+    $headAfter = (git rev-parse HEAD 2>$null)
+
+    # Step 2b: Reinstall ~/.gitconfig if the template changed during this pull.
+    # ~/.gitconfig is rendered from .gitconfig.template, so template changes
+    # download on pull but only take effect after regeneration.
+    if ($headBefore -ne $headAfter) {
+        $templateChanged = git diff --name-only $headBefore $headAfter -- .gitconfig.template
+        if ($templateChanged) {
+            Write-Log ".gitconfig.template changed; regenerating ~/.gitconfig..."
+            $initScript = Join-Path $PSScriptRoot "Initialize-GitConfig.ps1"
+            & $initScript -Force 2>&1 | ForEach-Object { Write-Log $_ }
+            if ($LASTEXITCODE -eq 0) {
+                Write-Log "SUCCESS: ~/.gitconfig regenerated from template (previous saved to ~/.gitconfig.bak)"
+            }
+            else {
+                Write-Log "ERROR: Failed to regenerate ~/.gitconfig from template (exit code $LASTEXITCODE)"
+            }
+        }
+        else {
+            Write-Log "No .gitconfig.template changes; skipping regeneration"
+        }
+    }
+    else {
+        Write-Log "No new commits pulled; skipping regeneration"
     }
 
     # Step 3: Sync all remote tracking branches

--- a/tests/Update-GitConfig.Tests.ps1
+++ b/tests/Update-GitConfig.Tests.ps1
@@ -1,7 +1,7 @@
 BeforeAll {
     # Setup variables
     $script:repoRoot = Split-Path -Parent $PSScriptRoot
-    $script:scriptPath = Join-Path $script:repoRoot "scripts\Update-GitConfig.ps1"
+    $script:scriptPath = Join-Path $script:repoRoot "scripts\windows version\Update-GitConfig.ps1"
     $script:testRepo = Join-Path $TestDrive "test-repo"
     $script:logFile = Join-Path $script:testRepo "docs\update-gitconfig.log"
 
@@ -557,6 +557,98 @@ Describe "Update-GitConfig.ps1" {
             # Note: Branch creation may or may not log depending on whether it already exists
             $logContent | Should -Match "SUCCESS: Remote tracking branches synchronized"
             $logContent | Should -Match "Repository synchronization process completed"
+        }
+    }
+
+    Context "Step 2b: Regenerate ~/.gitconfig on Template Change" {
+        BeforeEach {
+            $script:remoteRepo = Join-Path $TestDrive "remote-repo"
+            $script:fakeHome = Join-Path $TestDrive "fake-home"
+            New-RemoteRepository -Path $script:remoteRepo
+            New-Item -Path $script:fakeHome -ItemType Directory -Force | Out-Null
+
+            # Local clone laid out like the gitconfig repo, tracking main
+            New-Item -Path $script:testRepo -ItemType Directory -Force | Out-Null
+            Push-Location $script:testRepo
+            try {
+                git clone $script:remoteRepo . 2>&1 | Out-Null
+                git config user.email "test@example.com"
+                git config user.name "Test User"
+                git config commit.gpgsign false
+                New-Item -Path "docs" -ItemType Directory -Force | Out-Null
+                "[core]`n`teditor = nano`n" | Out-File -FilePath ".gitconfig.template" -Encoding utf8
+                "# readme" | Out-File -FilePath "README.md" -Encoding utf8
+                git add . 2>&1 | Out-Null
+                git commit -m "Initial" 2>&1 | Out-Null
+                git push origin HEAD:main 2>&1 | Out-Null
+                git checkout -b main 2>&1 | Out-Null
+                git branch --set-upstream-to=origin/main main 2>&1 | Out-Null
+            }
+            finally {
+                Pop-Location
+            }
+
+            # Redirect home so regeneration never touches the real ~/.gitconfig
+            $script:savedUserProfile = $env:USERPROFILE
+            $script:savedHomeEnv = $env:HOME
+            $env:USERPROFILE = $script:fakeHome
+            $env:HOME = $script:fakeHome
+
+            if (Test-Path $script:logFile) {
+                Remove-Item $script:logFile -Force
+            }
+        }
+
+        AfterEach {
+            $env:USERPROFILE = $script:savedUserProfile
+            $env:HOME = $script:savedHomeEnv
+            foreach ($p in @($script:testRepo, $script:remoteRepo, $script:fakeHome)) {
+                if ($p -and (Test-Path $p)) {
+                    Remove-Item $p -Recurse -Force
+                }
+            }
+        }
+
+        # Push a change to the remote from a throwaway clone so the test repo's
+        # pull produces a real before/after diff.
+        function Push-RemoteChange {
+            param([string]$File, [string]$Content, [string]$Message)
+            $work = Join-Path $TestDrive ("work-" + [guid]::NewGuid().ToString("N"))
+            git clone $script:remoteRepo $work 2>&1 | Out-Null
+            Push-Location $work
+            try {
+                git config user.email "test@example.com"
+                git config user.name "Test User"
+                git config commit.gpgsign false
+                $Content | Out-File -FilePath $File -Encoding utf8
+                git add . 2>&1 | Out-Null
+                git commit -m $Message 2>&1 | Out-Null
+                git push origin HEAD:main 2>&1 | Out-Null
+            }
+            finally {
+                Pop-Location
+            }
+            Remove-Item $work -Recurse -Force
+        }
+
+        It "Should regenerate ~/.gitconfig when the template changed" {
+            Push-RemoteChange -File ".gitconfig.template" -Content "[core]`n`teditor = vim`n" -Message "Change template"
+
+            & $script:scriptPath -RepoPath $script:testRepo 2>&1 | Out-Null
+
+            $logContent = Get-Content $script:logFile -Raw
+            $logContent | Should -Match "regenerating ~/.gitconfig"
+            (Join-Path $script:fakeHome ".gitconfig") | Should -Exist
+        }
+
+        It "Should not regenerate when no template change occurred" {
+            Push-RemoteChange -File "README.md" -Content "# updated readme" -Message "Docs only"
+
+            & $script:scriptPath -RepoPath $script:testRepo 2>&1 | Out-Null
+
+            $logContent = Get-Content $script:logFile -Raw
+            $logContent | Should -Match "skipping regeneration"
+            (Join-Path $script:fakeHome ".gitconfig") | Should -Not -Exist
         }
     }
 }


### PR DESCRIPTION
Fixes #78

## Problem
The login auto-update only ran `git pull` + branch sync — it never rebuilt `~/.gitconfig` from the freshly-pulled `.gitconfig.template`. Template changes (new aliases, signing/push tweaks) downloaded on pull but never took effect until a manual re-run. The "auto-update" only half-worked.

## Changes
Make update = **pull + install**, automatically at login and on demand, with parity across macOS, Linux, and Windows.

- **`scripts/shared/update-gitconfig.sh`** (mac + linux): capture `HEAD` before/after pull; if `.gitconfig.template` changed, source `functions.sh` and call the existing `generate_gitconfig "$REPO_PATH" "$HOME" true` (force = non-interactive; already backs up to `~/.gitconfig.bak`).
- **`scripts/windows version/Update-GitConfig.ps1`**: same before/after HEAD check; on template change invoke the existing `Initialize-GitConfig.ps1 -Force` in the same dir.
- **`.gitconfig.template`**: add a `git selfupdate` alias that runs the same pull-and-install on demand, dispatching by OS (`MINGW*|MSYS*|CYGWIN*` → PowerShell, else bash) and passing the substituted `{{REPO_PATH}}` so it targets the correct repo regardless of install location.
- **`tests/Update-GitConfig.Tests.ps1`**: add `regen-on-template-change` and `no-regen-otherwise` Pester contexts (redirect `USERPROFILE` so the real `~/.gitconfig` is never touched). Also fixed a stale `scriptPath` (`scripts\` → `scripts\windows version\`).
- **`docs/CHANGELOG.md`**, **`README.md`**: document `git selfupdate` and the install-on-update behavior.

### Reused, not rewritten
- `generate_gitconfig()` in `scripts/shared/functions.sh` (force + backup already implemented)
- `Initialize-GitConfig.ps1` (`-Force` + backup already implemented)

## Deviation from the issue spec
The issue's alias passed no argument; the updater scripts default `RepoPath` to `~/Documents/Scripts/gitconfig`. To honor the stated goal of "target the repo by its substituted absolute path," the alias now passes `{{REPO_PATH}}` explicitly to both the bash and PowerShell branches, so `git selfupdate` works even when the repo is installed elsewhere.

## Testing
**Linux (verified locally):**
- Template change in a pull → `~/.gitconfig` regenerated, old config backed up to `.bak`, `{{REPO_PATH}}`/`{{HOME_DIR}}` substituted correctly.
- Non-template change → no regeneration, no backup, log says "skipping regeneration".
- Rendered `selfupdate` alias parses as valid git config (`git config --file ... --list`), spaced paths survive quoting.

**Windows:** `Update-GitConfig.ps1`, the alias's PowerShell branch, and Pester to be verified on a Windows machine (cannot run PowerShell/Pester from the Linux dev VM).

## Acceptance criteria
- [x] Editing `.gitconfig.template` and letting auto-update run updates `~/.gitconfig` with no manual install (verified, Linux)
- [x] `git selfupdate` performs pull + install on demand (bash path verified on Linux; PowerShell path pending Windows)
- [x] Existing `~/.gitconfig` backed up before regeneration; `~/.gitconfig.local` never modified
- [x] No regeneration when `.gitconfig.template` did not change (verified, Linux)
- [x] Behavior consistent across macOS, Linux, Windows