### PR TITLE
fix: update stale Pester script paths to scripts/windows version/

### DIFF
--- a/tests/Cleanup-GitConfig.Tests.ps1
+++ b/tests/Cleanup-GitConfig.Tests.ps1
@@ -1,7 +1,7 @@
 BeforeAll {
     # Import the script
     $repoRoot = Split-Path -Parent $PSScriptRoot
-    $scriptPath = Join-Path $repoRoot "scripts\Cleanup-GitConfig.ps1"
+    $scriptPath = Join-Path $repoRoot "scripts\windows version\Cleanup-GitConfig.ps1"
 
     # Test variables
     $testHome = $env:USERPROFILE

--- a/tests/Initialize-GitConfig.Tests.ps1
+++ b/tests/Initialize-GitConfig.Tests.ps1
@@ -1,7 +1,7 @@
 BeforeAll {
     # Setup variables
     $script:repoRoot = Split-Path -Parent $PSScriptRoot
-    $script:scriptPath = Join-Path $script:repoRoot "scripts\Initialize-GitConfig.ps1"
+    $script:scriptPath = Join-Path $script:repoRoot "scripts\windows version\Initialize-GitConfig.ps1"
     $script:templatePath = Join-Path $script:repoRoot ".gitconfig.template"
     $script:testHome = $env:USERPROFILE
     if (-not $script:testHome) {

--- a/tests/Integration.Tests.ps1
+++ b/tests/Integration.Tests.ps1
@@ -1,7 +1,7 @@
 BeforeAll {
     $script:repoRoot = Split-Path -Parent $PSScriptRoot
-    $script:setupScript = Join-Path $script:repoRoot "scripts\install.ps1"
-    $script:cleanupScript = Join-Path $script:repoRoot "scripts\Cleanup-GitConfig.ps1"
+    $script:setupScript = Join-Path $script:repoRoot "scripts\windows version\install.ps1"
+    $script:cleanupScript = Join-Path $script:repoRoot "scripts\windows version\Cleanup-GitConfig.ps1"
     $script:testHome = $env:USERPROFILE
     if (-not $script:testHome) {
         $script:testHome = $env:HOME  # Unix/Linux fallback

--- a/tests/Setup-GitConfig.Tests.ps1
+++ b/tests/Setup-GitConfig.Tests.ps1
@@ -1,7 +1,7 @@
 BeforeAll {
     # Setup variables
     $script:repoRoot = Split-Path -Parent $PSScriptRoot
-    $script:scriptPath = Join-Path $script:repoRoot "scripts\install.ps1"
+    $script:scriptPath = Join-Path $script:repoRoot "scripts\windows version\install.ps1"
     $script:testHome = $env:USERPROFILE
     if (-not $script:testHome) {
         $script:testHome = $env:HOME  # Unix/Linux fallback


### PR DESCRIPTION
Fixes #80

## Problem
The PowerShell scripts were relocated into `scripts/windows version/`, but four Pester suites still resolved `$script:repoRoot`-relative paths under the old `scripts/` root. Their "Should exist" assertions (and anything that dot-sources the scripts) failed because the paths no longer exist.

## Changes
| File | Path corrected |
|------|----------------|
| `tests/Setup-GitConfig.Tests.ps1` | `scripts\install.ps1` → `scripts\windows version\install.ps1` |
| `tests/Integration.Tests.ps1` | `scripts\install.ps1` → `scripts\windows version\install.ps1` |
| `tests/Integration.Tests.ps1` | `scripts\Cleanup-GitConfig.ps1` → `scripts\windows version\Cleanup-GitConfig.ps1` |
| `tests/Initialize-GitConfig.Tests.ps1` | `scripts\Initialize-GitConfig.ps1` → `scripts\windows version\Initialize-GitConfig.ps1` |
| `tests/Cleanup-GitConfig.Tests.ps1` | `scripts\Cleanup-GitConfig.ps1` → `scripts\windows version\Cleanup-GitConfig.ps1` |

`tests/Update-GitConfig.Tests.ps1` was already fixed in #79 and is left untouched.

## Verification
Confirmed all corrected targets exist under `scripts/windows version/`:
- `install.ps1`
- `Cleanup-GitConfig.ps1`
- `Initialize-GitConfig.ps1`

Pester runs on Windows only, so full suite verification is **pending a Windows machine**.