### PR TITLE
feat: add skill-sync and skill-publish aliases for the claude-skills repo

### DIFF
--- a/.gitconfig.template
+++ b/.gitconfig.template
@@ -33,6 +33,12 @@
     main = !"command -v python3 >/dev/null && python3 {{REPO_PATH}}/gitconfig_helper.py switch_to_main \"$@\" || python {{REPO_PATH}}/gitconfig_helper.py switch_to_main \"$@\""
     # Manage machine-specific git configuration
     localconfig = !git config --file ~/.gitconfig.local
+    # Sync the claude-skills repo (~/.claude/skills) on demand, mirroring the
+    # auto-sync's --ff-only safety. Read-only; runs from any directory.
+    skill-sync = !git -C ~/.claude/skills pull --ff-only
+    # Commit (signed) and push the claude-skills repo (~/.claude/skills) from any
+    # directory: git skill-push "your message". A clean tree is a no-op.
+    skill-push = !"command -v python3 >/dev/null && python3 {{REPO_PATH}}/gitconfig_helper.py skill_push \"$@\" || python {{REPO_PATH}}/gitconfig_helper.py skill_push \"$@\""
     # Pull the latest gitconfig repo and reinstall ~/.gitconfig from the template
     # on demand. Dispatches by OS: Git-for-Windows reports MINGW/MSYS/CYGWIN.
     selfupdate = "!f() { case \"$(uname -s)\" in MINGW*|MSYS*|CYGWIN*) powershell -NoProfile -File '{{REPO_PATH}}/scripts/windows version/Update-GitConfig.ps1' -RepoPath '{{REPO_PATH}}' ;; *) bash '{{REPO_PATH}}/scripts/shared/update-gitconfig.sh' '{{REPO_PATH}}' ;; esac; }; f"

--- a/.gitconfig.template
+++ b/.gitconfig.template
@@ -36,9 +36,11 @@
     # Sync the claude-skills repo (~/.claude/skills) on demand, mirroring the
     # auto-sync's --ff-only safety. Read-only; runs from any directory.
     skill-sync = !git -C ~/.claude/skills pull --ff-only
-    # Commit (signed) and push the claude-skills repo (~/.claude/skills) from any
-    # directory: git skill-push "your message". A clean tree is a no-op.
-    skill-push = !"command -v python3 >/dev/null && python3 {{REPO_PATH}}/gitconfig_helper.py skill_push \"$@\" || python {{REPO_PATH}}/gitconfig_helper.py skill_push \"$@\""
+    # Publish new/edited skills in the claude-skills repo (~/.claude/skills) via a
+    # PR (its main is branch-protected): branches off main, prompts for a commit
+    # message, makes a signed commit, opens a PR, and enables squash auto-merge.
+    # Dispatches by OS like selfupdate; runs from any directory.
+    skill-publish = "!f() { case \"$(uname -s)\" in MINGW*|MSYS*|CYGWIN*) powershell -NoProfile -ExecutionPolicy Bypass -File \"$USERPROFILE\\.claude\\skills\\scripts\\publish-skill.ps1\" ;; *) bash \"$HOME/.claude/skills/scripts/publish-skill.sh\" ;; esac; }; f"
     # Pull the latest gitconfig repo and reinstall ~/.gitconfig from the template
     # on demand. Dispatches by OS: Git-for-Windows reports MINGW/MSYS/CYGWIN.
     selfupdate = "!f() { case \"$(uname -s)\" in MINGW*|MSYS*|CYGWIN*) powershell -NoProfile -File '{{REPO_PATH}}/scripts/windows version/Update-GitConfig.ps1' -RepoPath '{{REPO_PATH}}' ;; *) bash '{{REPO_PATH}}/scripts/shared/update-gitconfig.sh' '{{REPO_PATH}}' ;; esac; }; f"

--- a/README.md
+++ b/README.md
@@ -86,6 +86,8 @@ git cleanup        # Clean up merged local branches
 git main           # Switch to main with fetch, pull, and branch cleanup
 git main --all     # Run the above for every git repo in immediate subdirectories (alias: -a)
 git selfupdate     # Pull this repo and reinstall ~/.gitconfig from the template
+git skill-sync           # Sync the claude-skills repo (~/.claude/skills) with pull --ff-only
+git skill-push "msg"     # Commit (signed) and push the claude-skills repo from any directory
 ```
 
 ### Setup Script Options (Windows)

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ git main           # Switch to main with fetch, pull, and branch cleanup
 git main --all     # Run the above for every git repo in immediate subdirectories (alias: -a)
 git selfupdate     # Pull this repo and reinstall ~/.gitconfig from the template
 git skill-sync           # Sync the claude-skills repo (~/.claude/skills) with pull --ff-only
-git skill-push "msg"     # Commit (signed) and push the claude-skills repo from any directory
+git skill-publish        # Publish new/edited skills via a PR (prompts for a message, auto-merges)
 ```
 
 ### Setup Script Options (Windows)

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `git selfupdate` alias — pulls the gitconfig repo and reinstalls `~/.gitconfig` from
   the template on demand, dispatching to the correct platform script
   (PowerShell on Windows, bash on macOS/Linux) ([#78](https://github.com/J-MaFf/gitconfig/issues/78))
+- `git skill-sync` alias — on-demand `pull --ff-only` of the claude-skills repo
+  (`~/.claude/skills`), mirroring the auto-sync's fast-forward-only safety ([#83](https://github.com/J-MaFf/gitconfig/issues/83))
+- `git skill-push "msg"` alias — commit (signed) and push the claude-skills repo
+  (`~/.claude/skills`) from any directory; a clean working tree is a graceful no-op ([#82](https://github.com/J-MaFf/gitconfig/issues/82))
 
 ### Fixed
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -14,8 +14,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (PowerShell on Windows, bash on macOS/Linux) ([#78](https://github.com/J-MaFf/gitconfig/issues/78))
 - `git skill-sync` alias — on-demand `pull --ff-only` of the claude-skills repo
   (`~/.claude/skills`), mirroring the auto-sync's fast-forward-only safety ([#83](https://github.com/J-MaFf/gitconfig/issues/83))
-- `git skill-push "msg"` alias — commit (signed) and push the claude-skills repo
-  (`~/.claude/skills`) from any directory; a clean working tree is a graceful no-op ([#82](https://github.com/J-MaFf/gitconfig/issues/82))
+- `git skill-publish` alias — publish new/edited skills in the claude-skills repo
+  (`~/.claude/skills`) from any directory via a PR. Delegates to that repo's
+  `publish-skill` script (branch → signed commit → PR → squash auto-merge), since its
+  `main` is now branch-protected and can't be pushed to directly. Dispatches by OS
+  like `selfupdate` ([#82](https://github.com/J-MaFf/gitconfig/issues/82))
 
 ### Fixed
 

--- a/gitconfig_helper.py
+++ b/gitconfig_helper.py
@@ -185,6 +185,66 @@ def cleanup_branches(force=False):
         console.print(f"[red]Error running git cleanup: {e}[/red]")
 
 
+SKILLS_REPO = os.path.expanduser("~/.claude/skills")
+
+
+def skill_push(message):
+    """Commit and push all changes in the claude-skills repo (~/.claude/skills).
+
+    Runs add -A, commit (signed, via the repo's commit.gpgsign config), and push,
+    targeting ~/.claude/skills regardless of the current working directory.
+    A clean working tree is handled gracefully (no error, nothing to push).
+
+    Args:
+        message: Commit message. Passed through argv so it is quote-safe and is
+                 never re-parsed by a shell.
+
+    Returns 0 on success (including the nothing-to-commit case), 1 on failure.
+    """
+    console = Console()
+
+    if not message or not message.strip():
+        console.print("[red]Error: a commit message is required[/red]")
+        console.print('[yellow]Usage: git skill-push "your message"[/yellow]')
+        return 1
+
+    if not os.path.isdir(SKILLS_REPO):
+        console.print(f"[red]Error: skills repo not found at {SKILLS_REPO}[/red]")
+        return 1
+
+    # Stage everything (additions, modifications, deletions).
+    result = run_git("-C", SKILLS_REPO, "add", "-A")
+    if result.returncode != 0:
+        console.print("[red]Error: failed to stage changes[/red]")
+        console.print(f"[red]{result.stderr.strip()}[/red]")
+        return 1
+
+    # If nothing is staged, there is nothing to commit or push — exit cleanly.
+    status = run_git("-C", SKILLS_REPO, "status", "--porcelain")
+    if not status.stdout.strip():
+        console.print("[dim]Nothing to commit — skills repo is already clean.[/dim]")
+        return 0
+
+    # Commit. Signing is governed by the repo's commit.gpgsign config; we do not
+    # pass --no-gpg-sign, so signed commits stay signed.
+    console.print("[cyan]Committing changes in skills repo...[/cyan]")
+    commit = run_git("-C", SKILLS_REPO, "commit", "-m", message)
+    if commit.returncode != 0:
+        console.print("[red]Error: commit failed[/red]")
+        console.print(f"[red]{(commit.stderr or commit.stdout).strip()}[/red]")
+        return 1
+
+    console.print("[cyan]Pushing to remote...[/cyan]")
+    push = run_git("-C", SKILLS_REPO, "push")
+    if push.returncode != 0:
+        console.print("[red]Error: push failed[/red]")
+        console.print(f"[red]{(push.stderr or push.stdout).strip()}[/red]")
+        return 1
+
+    console.print("[green]OK Skills repo committed and pushed.[/green]")
+    return 0
+
+
 def get_git_aliases():
     """Dynamically fetch all git aliases from git config."""
     # Human-readable descriptions for known aliases
@@ -193,6 +253,8 @@ def get_git_aliases():
         "branches": "Download all remote branches and create local tracking branches",
         "cleanup": "Delete branches with deleted remotes (merged). Use --force to also delete local-only branches",
         "main": "Switch to main (fetch, pull, cleanup). Use --all/-a for every repo in immediate subdirectories",
+        "skill-sync": "Sync the claude-skills repo (~/.claude/skills): pull --ff-only",
+        "skill-push": "Commit and push the claude-skills repo (~/.claude/skills): git skill-push \"msg\"",
     }
 
     try:
@@ -421,6 +483,11 @@ if __name__ == "__main__":
             sys.exit(switch_to_main())
         elif function_name == "update_all_main":
             sys.exit(update_all_main())
+        elif function_name == "skill_push":
+            # The commit message is everything after the subcommand. Joining the
+            # remaining argv keeps it quote-safe and tolerant of unquoted messages.
+            message = " ".join(sys.argv[2:])
+            sys.exit(skill_push(message))
         else:
             print(f"Function {function_name} not found.")
     else:

--- a/gitconfig_helper.py
+++ b/gitconfig_helper.py
@@ -185,66 +185,6 @@ def cleanup_branches(force=False):
         console.print(f"[red]Error running git cleanup: {e}[/red]")
 
 
-SKILLS_REPO = os.path.expanduser("~/.claude/skills")
-
-
-def skill_push(message):
-    """Commit and push all changes in the claude-skills repo (~/.claude/skills).
-
-    Runs add -A, commit (signed, via the repo's commit.gpgsign config), and push,
-    targeting ~/.claude/skills regardless of the current working directory.
-    A clean working tree is handled gracefully (no error, nothing to push).
-
-    Args:
-        message: Commit message. Passed through argv so it is quote-safe and is
-                 never re-parsed by a shell.
-
-    Returns 0 on success (including the nothing-to-commit case), 1 on failure.
-    """
-    console = Console()
-
-    if not message or not message.strip():
-        console.print("[red]Error: a commit message is required[/red]")
-        console.print('[yellow]Usage: git skill-push "your message"[/yellow]')
-        return 1
-
-    if not os.path.isdir(SKILLS_REPO):
-        console.print(f"[red]Error: skills repo not found at {SKILLS_REPO}[/red]")
-        return 1
-
-    # Stage everything (additions, modifications, deletions).
-    result = run_git("-C", SKILLS_REPO, "add", "-A")
-    if result.returncode != 0:
-        console.print("[red]Error: failed to stage changes[/red]")
-        console.print(f"[red]{result.stderr.strip()}[/red]")
-        return 1
-
-    # If nothing is staged, there is nothing to commit or push — exit cleanly.
-    status = run_git("-C", SKILLS_REPO, "status", "--porcelain")
-    if not status.stdout.strip():
-        console.print("[dim]Nothing to commit — skills repo is already clean.[/dim]")
-        return 0
-
-    # Commit. Signing is governed by the repo's commit.gpgsign config; we do not
-    # pass --no-gpg-sign, so signed commits stay signed.
-    console.print("[cyan]Committing changes in skills repo...[/cyan]")
-    commit = run_git("-C", SKILLS_REPO, "commit", "-m", message)
-    if commit.returncode != 0:
-        console.print("[red]Error: commit failed[/red]")
-        console.print(f"[red]{(commit.stderr or commit.stdout).strip()}[/red]")
-        return 1
-
-    console.print("[cyan]Pushing to remote...[/cyan]")
-    push = run_git("-C", SKILLS_REPO, "push")
-    if push.returncode != 0:
-        console.print("[red]Error: push failed[/red]")
-        console.print(f"[red]{(push.stderr or push.stdout).strip()}[/red]")
-        return 1
-
-    console.print("[green]OK Skills repo committed and pushed.[/green]")
-    return 0
-
-
 def get_git_aliases():
     """Dynamically fetch all git aliases from git config."""
     # Human-readable descriptions for known aliases
@@ -254,7 +194,7 @@ def get_git_aliases():
         "cleanup": "Delete branches with deleted remotes (merged). Use --force to also delete local-only branches",
         "main": "Switch to main (fetch, pull, cleanup). Use --all/-a for every repo in immediate subdirectories",
         "skill-sync": "Sync the claude-skills repo (~/.claude/skills): pull --ff-only",
-        "skill-push": "Commit and push the claude-skills repo (~/.claude/skills): git skill-push \"msg\"",
+        "skill-publish": "Publish new/edited skills (~/.claude/skills) via a PR with auto-merge",
     }
 
     try:
@@ -483,11 +423,6 @@ if __name__ == "__main__":
             sys.exit(switch_to_main())
         elif function_name == "update_all_main":
             sys.exit(update_all_main())
-        elif function_name == "skill_push":
-            # The commit message is everything after the subcommand. Joining the
-            # remaining argv keeps it quote-safe and tolerant of unquoted messages.
-            message = " ".join(sys.argv[2:])
-            sys.exit(skill_push(message))
         else:
             print(f"Function {function_name} not found.")
     else:

--- a/tests/gitconfig_helper.Tests.ps1
+++ b/tests/gitconfig_helper.Tests.ps1
@@ -85,6 +85,37 @@ import gitconfig_helper
         }
     }
 
+    Context "skill_push Function" {
+        It "Should be defined in the script" {
+            $scriptContent = Get-Content $helperScript -Raw
+            $scriptContent | Should -Match "def skill_push"
+        }
+
+        It "Should target the ~/.claude/skills repo" {
+            $scriptContent = Get-Content $helperScript -Raw
+            $scriptContent | Should -Match "\.claude/skills"
+        }
+
+        It "Should require a commit message" {
+            # No message provided -> error and non-zero exit
+            $result = & python $helperScript skill_push 2>&1
+            $output = $result -join "`n"
+            $output | Should -Match "commit message is required"
+            $LASTEXITCODE | Should -Be 1
+        }
+
+        It "Should not bypass commit signing" {
+            # Must never pass --no-gpg-sign; signing is governed by repo config
+            $scriptContent = Get-Content $helperScript -Raw
+            $scriptContent | Should -Not -Match "no-gpg-sign"
+        }
+
+        It "Should handle a clean working tree gracefully (nothing to commit)" {
+            $scriptContent = Get-Content $helperScript -Raw
+            ($scriptContent -match "Nothing to commit" -or $scriptContent -match "status.*porcelain") | Should -Be $true
+        }
+    }
+
     Context "get_git_aliases Function" {
         It "Should be defined in the script" {
             $scriptContent = Get-Content $helperScript -Raw

--- a/tests/gitconfig_helper.Tests.ps1
+++ b/tests/gitconfig_helper.Tests.ps1
@@ -85,34 +85,18 @@ import gitconfig_helper
         }
     }
 
-    Context "skill_push Function" {
-        It "Should be defined in the script" {
+    Context "skill aliases" {
+        It "skill-publish should be described in alias_descriptions" {
             $scriptContent = Get-Content $helperScript -Raw
-            $scriptContent | Should -Match "def skill_push"
+            $scriptContent | Should -Match '"skill-publish"'
         }
 
-        It "Should target the ~/.claude/skills repo" {
+        It "should no longer define the obsolete skill_push helper" {
+            # skill publishing now lives in the claude-skills publish-skill script,
+            # which opens a PR (its main is branch-protected); the helper must not
+            # push straight to main any more.
             $scriptContent = Get-Content $helperScript -Raw
-            $scriptContent | Should -Match "\.claude/skills"
-        }
-
-        It "Should require a commit message" {
-            # No message provided -> error and non-zero exit
-            $result = & python $helperScript skill_push 2>&1
-            $output = $result -join "`n"
-            $output | Should -Match "commit message is required"
-            $LASTEXITCODE | Should -Be 1
-        }
-
-        It "Should not bypass commit signing" {
-            # Must never pass --no-gpg-sign; signing is governed by repo config
-            $scriptContent = Get-Content $helperScript -Raw
-            $scriptContent | Should -Not -Match "no-gpg-sign"
-        }
-
-        It "Should handle a clean working tree gracefully (nothing to commit)" {
-            $scriptContent = Get-Content $helperScript -Raw
-            ($scriptContent -match "Nothing to commit" -or $scriptContent -match "status.*porcelain") | Should -Be $true
+            $scriptContent | Should -Not -Match "def skill_push"
         }
     }
 


### PR DESCRIPTION
Fixes #82
Fixes #83

## Summary

Adds two git aliases for the **separate** `J-MaFf/claude-skills` repo (checked out at `~/.claude/skills` on every machine). Both run from **any** directory.

### `git skill-sync` (#83)
Read-only on-demand sync, mirroring the auto-sync's fast-forward-only safety:

```
git -C ~/.claude/skills pull --ff-only
```

Plain shell alias in `.gitconfig.template`.

### `git skill-publish` (#82)
Publishes new/edited skills **via a PR**. The claude-skills `main` is now branch-protected (required CI checks, no direct pushes), so a plain commit+push to main no longer works. This alias delegates to that repo's own `publish-skill` script, which:

1. branches off the latest `main` (auto-named `feat/`/`docs/`/`chore/`)
2. stages all skill changes
3. prompts for a commit message
4. makes a **signed** commit
5. opens a PR (assignee + label)
6. enables `--auto --squash --delete-branch` so GitHub merges once CI is green

The alias dispatches by OS exactly like `selfupdate` — `publish-skill.ps1` on Windows, `publish-skill.sh` elsewhere.

## Change from the earlier approach

This PR originally added a `skill_push` subcommand in `gitconfig_helper.py` that ran `add -A; commit; push` straight to the skills repo's `main`. That path is now obsolete (branch protection rejects it), so it's removed in favor of delegating to the canonical `publish-skill` script — single source of truth, no duplicated workflow logic.

## Files changed

- **`.gitconfig.template`** — `skill-sync` (shell alias) + `skill-publish` (OS-dispatched call into the publish-skill script).
- **`gitconfig_helper.py`** — removed the obsolete `skill_push` function / dispatch / `SKILLS_REPO`; added the `skill-publish` description.
- **`tests/gitconfig_helper.Tests.ps1`** — dropped the `skill_push` unit tests; assert the helper no longer defines it.
- **`README.md` / `docs/CHANGELOG.md`** — documented `skill-sync` and `skill-publish`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)