### PR TITLE
fix: make install.ps1 ASCII-safe for Windows PowerShell 5.1

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -22,6 +22,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `install.ps1` no longer fails to parse under Windows PowerShell 5.1. The script
+  contained em dash characters (`—`) and lacked a UTF-8 BOM, so the legacy ANSI-codepage
+  reader mangled them into smart-quotes that broke string literals. Em dashes are now
+  ASCII hyphens and the file carries a BOM. Added a Pester guard test
+  (`tests/Encoding.Tests.ps1`) asserting every `scripts/windows version/*.ps1` is
+  ASCII-only and parses cleanly ([#85](https://github.com/J-MaFf/gitconfig/issues/85))
 - Login auto-update now reinstalls `~/.gitconfig` when `.gitconfig.template` changed
   during the pull, instead of only pulling. Template changes (new aliases, signing/push
   tweaks) take effect automatically with no manual re-run. The existing `~/.gitconfig`

--- a/scripts/windows version/install.ps1
+++ b/scripts/windows version/install.ps1
@@ -1,4 +1,4 @@
-# GitConfig Setup Wrapper
+﻿# GitConfig Setup Wrapper
 # Orchestrates complete setup of portable git configuration
 # Requires administrator privileges
 
@@ -172,16 +172,16 @@ if ($pipCmd) {
                 Write-Host "[OK] Installed Python 'rich'" -ForegroundColor Green
             }
             else {
-                Write-Host "[WARN] Could not install 'rich' — run manually: pip install rich" -ForegroundColor Yellow
+                Write-Host "[WARN] Could not install 'rich' - run manually: pip install rich" -ForegroundColor Yellow
             }
         }
         catch {
-            Write-Host "[WARN] Could not install 'rich' — run manually: pip install rich" -ForegroundColor Yellow
+            Write-Host "[WARN] Could not install 'rich' - run manually: pip install rich" -ForegroundColor Yellow
         }
     }
 }
 else {
-    Write-Host "[WARN] pip not found — install Python 3 from https://python.org" -ForegroundColor Yellow
+    Write-Host "[WARN] pip not found - install Python 3 from https://python.org" -ForegroundColor Yellow
 }
 Write-Host ""
 
@@ -212,7 +212,7 @@ if ($pyCmd) {
     }
 }
 else {
-    Write-Host "[WARN] Python not found — cannot verify 'rich'" -ForegroundColor Yellow
+    Write-Host "[WARN] Python not found - cannot verify 'rich'" -ForegroundColor Yellow
 }
 
 try {

--- a/tests/Encoding.Tests.ps1
+++ b/tests/Encoding.Tests.ps1
@@ -1,0 +1,32 @@
+BeforeDiscovery {
+    # Discover every Windows PowerShell script so each gets its own test case.
+    $repoRoot = Split-Path -Parent $PSScriptRoot
+    $windowsScriptDir = Join-Path $repoRoot "scripts\windows version"
+    $scriptFiles = Get-ChildItem -Path $windowsScriptDir -Filter *.ps1 -File |
+        ForEach-Object { @{ Path = $_.FullName; Name = $_.Name } }
+}
+
+Describe "Windows script encoding" -Tag 'Unit' {
+
+    # Windows PowerShell 5.1 reads BOM-less files as the system ANSI codepage.
+    # Any non-ASCII character (e.g. an em dash) is then decoded into garbage
+    # bytes, one of which can be treated as a smart-quote and break parsing.
+    # Keeping these scripts ASCII-only guarantees they parse under 5.1.
+    Context "<Name>" -ForEach $scriptFiles {
+
+        It "contains only ASCII characters" {
+            $text = [System.IO.File]::ReadAllText($Path)
+            $nonAscii = [regex]::Matches($text, '[^\x00-\x7F]')
+            $detail = ($nonAscii |
+                ForEach-Object { 'U+{0:X4}' -f [int][char]$_.Value } |
+                Select-Object -Unique) -join ', '
+            $nonAscii.Count | Should -Be 0 -Because "non-ASCII chars break Windows PowerShell 5.1 parsing (found: $detail)"
+        }
+
+        It "parses without syntax errors" {
+            $errors = $null
+            $null = [System.Management.Automation.Language.Parser]::ParseFile($Path, [ref]$null, [ref]$errors)
+            $errors.Count | Should -Be 0 -Because "the script must be syntactically valid"
+        }
+    }
+}


### PR DESCRIPTION
Fixes #85

## Problem
`scripts/windows version/install.ps1` was UTF-8 without a BOM and contained 4 em dashes (`—`, U+2014) in `[WARN]` messages. Windows PowerShell 5.1 reads BOM-less files as the system ANSI codepage, decoding each em dash into bytes where `0x94` is treated as a smart double-quote. That terminates string literals early and cascades into misleading parser errors, breaking auto-elevated install on a clean machine:

```
The Try statement is missing its Catch or Finally block.
Array index expression is missing or not valid.
Missing closing ''}'' in statement block or type definition.
```

## Changes
- Replace em dashes with ASCII hyphens in `install.ps1`
- Add a UTF-8 BOM to `install.ps1`
- Add `tests/Encoding.Tests.ps1` — data-driven Pester test asserting every `scripts/windows version/*.ps1` is ASCII-only and parses without syntax errors (guards against reintroduction)
- Add CHANGELOG entry

## Testing
```
Invoke-Pester tests/Encoding.Tests.ps1
# Tests Passed: 14, Failed: 0  (7 scripts x 2 checks)
```
`[Parser]::ParseFile` reports no errors on the fixed `install.ps1`. Scanned all other repo `.ps1` files — they were already pure ASCII.