### PR TITLE
fix: make gitconfig_helper.py output ASCII-safe on legacy Windows console

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -22,6 +22,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `git cleanup` (and `git main`) no longer crash with `UnicodeEncodeError` on the
+  legacy Windows console. `gitconfig_helper.py` printed a `✓` checkmark and `──`
+  box-drawing characters via `rich`, which fall back to the cp1252 renderer and cannot
+  encode those glyphs. Replaced them with ASCII equivalents (`[OK]`, `--`) matching the
+  `[OK]`/`[WARN]` convention, and added a Pester guard asserting the helper is ASCII-only
+  ([#87](https://github.com/J-MaFf/gitconfig/issues/87))
 - `install.ps1` no longer fails to parse under Windows PowerShell 5.1. The script
   contained em dash characters (`—`) and lacked a UTF-8 BOM, so the legacy ANSI-codepage
   reader mangled them into smart-quotes that broke string literals. Em dashes are now

--- a/gitconfig_helper.py
+++ b/gitconfig_helper.py
@@ -174,7 +174,7 @@ def cleanup_branches(force=False):
 
             console.print(table)
             console.print(
-                f"[green]✓ Successfully deleted {len(deleted_branches)} branch(es)[/green]\n"
+                f"[green][OK] Successfully deleted {len(deleted_branches)} branch(es)[/green]\n"
             )
         else:
             console.print(
@@ -358,7 +358,7 @@ def update_all_main():
 
     results = []  # (repo_name, succeeded)
     for repo in repos:
-        console.print(f"\n[bold]── {repo} ──[/bold]")
+        console.print(f"\n[bold]-- {repo} --[/bold]")
         try:
             os.chdir(repo)
             succeeded = switch_to_main() == 0

--- a/tests/gitconfig_helper.Tests.ps1
+++ b/tests/gitconfig_helper.Tests.ps1
@@ -16,6 +16,18 @@ Describe "gitconfig_helper.py" {
             $LASTEXITCODE | Should -Be 0
         }
 
+        It "Script contains only ASCII characters" {
+            # rich falls back to the cp1252 renderer on the legacy Windows
+            # console, which raises UnicodeEncodeError on non-ASCII glyphs
+            # (e.g. checkmarks, box-drawing). Keep the helper ASCII-only.
+            $text = [System.IO.File]::ReadAllText($script:helperScript)
+            $nonAscii = [regex]::Matches($text, '[^\x00-\x7F]')
+            $detail = ($nonAscii |
+                ForEach-Object { 'U+{0:X4}' -f [int][char]$_.Value } |
+                Select-Object -Unique) -join ', '
+            $nonAscii.Count | Should -Be 0 -Because "non-ASCII glyphs crash rich on the legacy Windows console (found: $detail)"
+        }
+
         It "Script can be imported without errors" {
             $repoRootForward = $script:repoRoot -replace '\\', '/'
             $pythonCode = @"


### PR DESCRIPTION
Fixes #87

## Problem
`gitconfig_helper.py` prints a `✓` (U+2713) and `──` (U+2500) via `rich`. On the legacy `Windows PowerShell` console, `rich` falls back to its cp1252 renderer, which cannot encode those glyphs:

```
UnicodeEncodeError: ''charmap'' codec can''t encode character ''✓'' in position 0: character maps to <undefined>
```

This crashes `git cleanup` (branch deletion succeeds first, then the success message dumps a traceback and exits non-zero) and posed the same risk for `git main` via the repo headers. Same root-cause class as #85, but in the Python helper.

## Changes
- `gitconfig_helper.py:177` — `✓` → `[OK]` in the cleanup success message (matches the `[OK]`/`[WARN]` convention from `install.ps1`)
- `gitconfig_helper.py:361` — `── {repo} ──` → `-- {repo} --` in the switch-to-main header
- Added an ASCII-only Pester guard to `tests/gitconfig_helper.Tests.ps1`
- CHANGELOG entry

## Testing
```
Invoke-Pester tests/gitconfig_helper.Tests.ps1 -FullName ''*Script Validation*''
# Passed: 4/4, including the new "contains only ASCII characters" assertion
```
Helper now has 0 non-ASCII characters, so it can no longer raise `UnicodeEncodeError` against a cp1252 stream.