### PR TITLE
fix: remove .gitconfig from symlink list and fix Update-GitConfig.ps1 path

### DIFF
--- a/scripts/windows version/Initialize-Symlinks.ps1
+++ b/scripts/windows version/Initialize-Symlinks.ps1
@@ -36,7 +36,6 @@ EXAMPLE:
     .\Initialize-Symlinks.ps1 -Force
 
 FILES LINKED:
-    - .gitconfig
     - .gitignore_global
     - gitconfig_helper.py
 
@@ -66,8 +65,8 @@ Write-Host "Home Directory: $homeDir" -ForegroundColor Green
 Write-Host ""
 
 # Define files to symlink
+# .gitconfig is generated from .gitconfig.template into ~/ and must NOT be symlinked
 $filesToLink = @(
-    ".gitconfig",
     ".gitignore_global",
     "gitconfig_helper.py"
 )
@@ -112,7 +111,7 @@ function Register-LoginTask {
     )
 
     $taskName = "GitConfig Pull at Login"
-    $scriptPath = Join-Path $repoRoot "scripts\Update-GitConfig.ps1"
+    $scriptPath = Join-Path $repoRoot "scripts\windows version\Update-GitConfig.ps1"
 
     # Check if script exists
     if (-not (Test-Path $scriptPath)) {
@@ -215,7 +214,7 @@ if ($taskResponse -eq "y") {
     Write-Host ""
 }
 
-Write-Host "Your .gitconfig and gitconfig_helper.py are now symlinked from the repository." -ForegroundColor Cyan
+Write-Host "Your .gitignore_global and gitconfig_helper.py are now symlinked from the repository." -ForegroundColor Cyan
 Write-Host "Any changes pushed to the repository will be reflected in your home directory." -ForegroundColor Cyan
 Write-Host ""
 


### PR DESCRIPTION
Fixes #89

## Changes

- Remove `.gitconfig` from `$filesToLink` in `Initialize-Symlinks.ps1` — `.gitconfig` is generated from `.gitconfig.template` into `~/` by `Initialize-GitConfig.ps1` and has no source file in the repo to symlink from. This was causing `[FAIL] Source file not found` on every install.
- Fix `Register-LoginTask` function path from `scripts\Update-GitConfig.ps1` → `scripts\windows version\Update-GitConfig.ps1`. The wrong path caused `[WARN] Update-GitConfig.ps1 not found` when the user opted in to the scheduled task during symlink setup.
- Update help text (`FILES LINKED`) and success message to reflect the corrected file list.