### PR TITLE
fix: resolve Python launcher (py) first in git aliases on Windows

### DIFF
--- a/.gitconfig.template
+++ b/.gitconfig.template
@@ -23,14 +23,14 @@
 
 [alias]
     # List all aliases
-    alias = !"command -v python3 >/dev/null && python3 {{REPO_PATH}}/gitconfig_helper.py print_aliases || python {{REPO_PATH}}/gitconfig_helper.py print_aliases"
+    alias = !"f() { for p in py python3 python; do command -v \"$p\" >/dev/null 2>&1 && \"$p\" -c '' >/dev/null 2>&1 && exec \"$p\" {{REPO_PATH}}/gitconfig_helper.py print_aliases; done; echo 'No working Python found (tried py, python3, python)' >&2; return 1; }; f"
     # Download all remote branches creating local counterparts
     branches = "!git fetch && git for-each-ref --format='%(refname:short)' refs/remotes/origin/ | grep -v -e '^origin/HEAD$' -e '^origin$' | while read ref; do git branch --track \"${ref#origin/}\" \"$ref\" 2>/dev/null || true; done"
-    cleanup = !"command -v python3 >/dev/null && python3 {{REPO_PATH}}/gitconfig_helper.py cleanup \"$@\" || python {{REPO_PATH}}/gitconfig_helper.py cleanup \"$@\""
+    cleanup = !"f() { for p in py python3 python; do command -v \"$p\" >/dev/null 2>&1 && \"$p\" -c '' >/dev/null 2>&1 && exec \"$p\" {{REPO_PATH}}/gitconfig_helper.py cleanup \"$@\"; done; echo 'No working Python found (tried py, python3, python)' >&2; return 1; }; f"
     # Switch to main with error handling: fetch, check for uncommitted changes,
     # checkout main, and pull. Detects and reports merge conflicts.
     # Pass --all (or -a) to run this for every git repo in immediate subdirectories.
-    main = !"command -v python3 >/dev/null && python3 {{REPO_PATH}}/gitconfig_helper.py switch_to_main \"$@\" || python {{REPO_PATH}}/gitconfig_helper.py switch_to_main \"$@\""
+    main = !"f() { for p in py python3 python; do command -v \"$p\" >/dev/null 2>&1 && \"$p\" -c '' >/dev/null 2>&1 && exec \"$p\" {{REPO_PATH}}/gitconfig_helper.py switch_to_main \"$@\"; done; echo 'No working Python found (tried py, python3, python)' >&2; return 1; }; f"
     # Manage machine-specific git configuration
     localconfig = !git config --file ~/.gitconfig.local
     # Sync the claude-skills repo (~/.claude/skills) on demand, mirroring the

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -22,6 +22,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `git alias`, `git cleanup`, and `git main` no longer print a spurious
+  "Python was not found" line on Windows. The aliases resolved Python with
+  `command -v python3`, which matches the Microsoft Store app-execution-alias stub;
+  the stub ran first, emitted the message, and exited before the real `python` fallback.
+  The aliases now resolve `py -> python3 -> python` and verify each interpreter actually
+  runs (`-c ''`) before using it, skipping the stub. Apply on an installed machine with
+  `git selfupdate`. Added a Pester guard (`tests/GitconfigTemplate.Tests.ps1`)
+  ([#91](https://github.com/J-MaFf/gitconfig/issues/91))
 - `git cleanup` (and `git main`) no longer crash with `UnicodeEncodeError` on the
   legacy Windows console. `gitconfig_helper.py` printed a `✓` checkmark and `──`
   box-drawing characters via `rich`, which fall back to the cp1252 renderer and cannot

--- a/tests/GitconfigTemplate.Tests.ps1
+++ b/tests/GitconfigTemplate.Tests.ps1
@@ -1,0 +1,49 @@
+BeforeDiscovery {
+    $repoRoot = Split-Path -Parent $PSScriptRoot
+    $templatePath = Join-Path $repoRoot ".gitconfig.template"
+
+    # The aliases that shell out to gitconfig_helper.py. Each must resolve the
+    # Python interpreter as py -> python3 -> python so the Windows Microsoft
+    # Store stub (which masquerades as python3) is never invoked first.
+    $pythonAliases = @(
+        @{ Alias = 'alias' }
+        @{ Alias = 'cleanup' }
+        @{ Alias = 'main' }
+    )
+}
+
+Describe ".gitconfig.template Python alias resolution" -Tag 'Unit' {
+
+    BeforeAll {
+        $repoRoot = Split-Path -Parent $PSScriptRoot
+        $script:templateLines = Get-Content (Join-Path $repoRoot ".gitconfig.template")
+    }
+
+    Context "<Alias>" -ForEach $pythonAliases {
+
+        BeforeAll {
+            # Grab the single definition line for this alias (e.g. "    cleanup = ...").
+            $script:line = $templateLines | Where-Object { $_ -match "^\s*$Alias\s*=" } | Select-Object -First 1
+        }
+
+        It "is defined exactly once" {
+            ($templateLines | Where-Object { $_ -match "^\s*$Alias\s*=" }).Count | Should -Be 1
+        }
+
+        It "tries 'py' before 'python3' and 'python'" {
+            $line | Should -Match '\bpy\b'
+            $pyIdx = $line.IndexOf(' py ')
+            $py3Idx = $line.IndexOf('python3')
+            $pyIdx | Should -BeGreaterThan -1 -Because "the Python Launcher 'py' must be a resolution candidate"
+            $pyIdx | Should -BeLessThan $py3Idx -Because "py must be tried before the Microsoft Store stub 'python3'"
+        }
+
+        It "verifies the interpreter runs before using it (rejects the Store stub)" {
+            $line | Should -Match "-c ''"
+        }
+
+        It "does not use the old python3-first resolution" {
+            $line | Should -Not -Match 'command -v python3 >/dev/null &&'
+        }
+    }
+}


### PR DESCRIPTION
Fixes #91

## Problem
On Windows (Git Bash), `git alias`, `git cleanup`, and `git main` print a spurious line before their real output:

```
Python was not found; run without arguments to install from the Microsoft Store, ...
```

The aliases resolved Python with `command -v python3 >/dev/null && python3 <script> || python <script>`. On Windows, `python3` resolves to the Microsoft Store **app-execution-alias stub**, so `command -v` succeeds, the stub runs first, prints the message, and exits non-zero — then the `||` fallback runs real `python`, so output appears but with the noise.

Confirmed on the affected machine:
- `py` -> `/c/windows/py` (real launcher)
- `python3` -> `.../WindowsApps/python3` (stub); `python3 -c "` exits non-zero

## Fix
Rewrote the three Python-calling aliases to resolve `py -> python3 -> python` and verify each interpreter actually runs ("$p" -c "`) before using it, so the stub is skipped. Used a shell-function pattern (`!f() { ...; }; f`) so git argument appending passes args cleanly — verified git appends alias args to the end of the command.

Matches the git-policies convention (resolve executables explicitly, Python Launcher first).

## Testing
- Rendered alias runs with **no** stub message, exit 0
- Arg passthrough verified via the function pattern: `cleanup`, `cleanup --force`, `cleanup -f extra` — no duplication
- New guard `tests/GitconfigTemplate.Tests.ps1` passes 12/12 (asserts py-first, stub-rejection, and that the old python3-first form is gone)

> Note: `~/.gitconfig` is generated from `.gitconfig.template`. Apply on an installed machine with `git selfupdate`.