### PR TITLE
fix: make Push-RemoteChange visible to Step 2b Pester tests

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -33,6 +33,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Pester tests in the "Step 2b: Regenerate ~/.gitconfig on Template Change" context
+  no longer fail with `The term 'Push-RemoteChange' is not recognized`. The
+  `Push-RemoteChange` helper was defined directly in the `Context` body, which is not
+  visible inside `It` blocks under Pester v5; it's now declared in a `BeforeAll` so the
+  two affected tests run. No production code changed
+  ([#95](https://github.com/J-MaFf/gitconfig/issues/95))
 - `git alias`, `git cleanup`, and `git main` no longer print a spurious
   "Python was not found" line on Windows. The aliases resolved Python with
   `command -v python3`, which matches the Microsoft Store app-execution-alias stub;

--- a/tests/Update-GitConfig.Tests.ps1
+++ b/tests/Update-GitConfig.Tests.ps1
@@ -630,25 +630,29 @@ Describe "Update-GitConfig.ps1" {
         }
 
         # Push a change to the remote from a throwaway clone so the test repo's
-        # pull produces a real before/after diff.
-        function Push-RemoteChange {
-            param([string]$File, [string]$Content, [string]$Message)
-            $work = Join-Path $TestDrive ("work-" + [guid]::NewGuid().ToString("N"))
-            git clone $script:remoteRepo $work 2>&1 | Out-Null
-            Push-Location $work
-            try {
-                git config user.email "test@example.com"
-                git config user.name "Test User"
-                git config commit.gpgsign false
-                $Content | Out-File -FilePath $File -Encoding utf8
-                git add . 2>&1 | Out-Null
-                git commit -m $Message 2>&1 | Out-Null
-                git push origin HEAD:main 2>&1 | Out-Null
+        # pull produces a real before/after diff. Defined in BeforeAll so the
+        # function is visible inside the It blocks under Pester v5 (functions
+        # declared directly in a Context body are not).
+        BeforeAll {
+            function Push-RemoteChange {
+                param([string]$File, [string]$Content, [string]$Message)
+                $work = Join-Path $TestDrive ("work-" + [guid]::NewGuid().ToString("N"))
+                git clone $script:remoteRepo $work 2>&1 | Out-Null
+                Push-Location $work
+                try {
+                    git config user.email "test@example.com"
+                    git config user.name "Test User"
+                    git config commit.gpgsign false
+                    $Content | Out-File -FilePath $File -Encoding utf8
+                    git add . 2>&1 | Out-Null
+                    git commit -m $Message 2>&1 | Out-Null
+                    git push origin HEAD:main 2>&1 | Out-Null
+                }
+                finally {
+                    Pop-Location
+                }
+                Remove-Item $work -Recurse -Force
             }
-            finally {
-                Pop-Location
-            }
-            Remove-Item $work -Recurse -Force
         }
 
         It "Should regenerate ~/.gitconfig when the template changed" {


### PR DESCRIPTION
Fixes #95

## Problem

The **"Step 2b: Regenerate ~/.gitconfig on Template Change"** context in `tests/Update-GitConfig.Tests.ps1` defined the `Push-RemoteChange` helper directly in the `Context` script block. Under Pester v5, functions declared in a `Context`/`Describe` body are not in scope inside `It` blocks, so both tests failed:

```
The term 'Push-RemoteChange' is not recognized as a name of a cmdlet, function, script file, or executable program.
```

This was a pre-existing failure on `main`.

## Fix

Wrap the `Push-RemoteChange` definition in a `BeforeAll {}` within that `Context`. Pester v5 makes `BeforeAll`-defined functions available to the `It` blocks. The function reads `$script:remoteRepo` at call time (set in `BeforeEach`), so behavior is unchanged — no production code touched.

## Testing

```powershell
Invoke-Pester -Path "tests\Update-GitConfig.Tests.ps1"
```

- Before: `Tests Passed: 22, Failed: 2`
- After: `Tests Passed: 24, Failed: 0`