### PR TITLE
feat: generate ~/.ssh/allowed_signers so commit signatures verify locally

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,13 @@ python -m pip install rich
 
 **Aliases not working:** Verify the symlink exists and `.gitconfig` includes the helper path.
 
+**`git log --show-signature` says "No signature" on a signed commit:** Install writes a
+`~/.ssh/allowed_signers` entry for your signing key and points
+`gpg.ssh.allowedSignersFile` at it (in `~/.gitconfig.local`) so git can verify SSH
+signatures locally. If you signed before this was set up, re-run install (or
+`git selfupdate`) to regenerate it. GitHub verifies signatures independently, so commits
+show as Verified there regardless.
+
 ## License
 
 Personal configuration repository.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Setup now generates `~/.ssh/allowed_signers` and points `gpg.ssh.allowedSignersFile`
+  at it (in `~/.gitconfig.local`) so git can verify SSH commit signatures locally —
+  `git log --show-signature` and `git verify-commit` no longer report "No signature" on
+  signed commits. Works across Windows (1Password), macOS (1Password), and Linux
+  (file-based key); the entry is idempotent and preserves other identities. Shared bash
+  logic lives in `scripts/shared/functions.sh` (`update_allowed_signers`); added a Pester
+  guard (`tests/Initialize-LocalConfig.Tests.ps1`)
+  ([#97](https://github.com/J-MaFf/gitconfig/issues/97))
 - `git selfupdate` alias — pulls the gitconfig repo and reinstalls `~/.gitconfig` from
   the template on demand, dispatching to the correct platform script
   (PowerShell on Windows, bash on macOS/Linux) ([#78](https://github.com/J-MaFf/gitconfig/issues/78))

--- a/scripts/linux version/initialize-local-config.sh
+++ b/scripts/linux version/initialize-local-config.sh
@@ -6,6 +6,10 @@
 
 set -e
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=../shared/functions.sh
+source "$SCRIPT_DIR/../shared/functions.sh"
+
 FORCE=false
 HELP=false
 
@@ -89,14 +93,20 @@ CONFIG_CONTENT="# Machine-Specific Git Configuration (Linux)
 	excludesfile = $HOME_DIR/.gitignore_global
 "
 
+SIGNING_ENABLED=false
 if [ -f "$SIGNING_KEY_PATH" ]; then
     echo "[INFO] Detected SSH signing key: $SIGNING_KEY_PATH"
+    SIGNING_ENABLED=true
     CONFIG_CONTENT+="
 [user]
 	signingKey = $SIGNING_KEY_PATH
 
 [gpg]
 	format = ssh
+
+[gpg \"ssh\"]
+	# Lets git verify SSH commit signatures locally (git log --show-signature)
+	allowedSignersFile = $HOME_DIR/.ssh/allowed_signers
 
 [commit]
 	gpgsign = true
@@ -126,5 +136,13 @@ CONFIG_CONTENT+="
 printf '%s\n' "$CONFIG_CONTENT" > "$LOCAL_CONFIG_PATH"
 echo "[OK] Created .gitconfig.local"
 echo ""
+
+# When signing is enabled, register the signing identity so git can verify
+# SSH commit signatures locally.
+if [ "$SIGNING_ENABLED" = true ]; then
+    update_allowed_signers "$HOME_DIR/.ssh/allowed_signers"
+    echo ""
+fi
+
 echo "To add safe directories, edit: $LOCAL_CONFIG_PATH"
 echo ""

--- a/scripts/mac version/initialize-local-config.sh
+++ b/scripts/mac version/initialize-local-config.sh
@@ -5,6 +5,10 @@
 
 set -e
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=../shared/functions.sh
+source "$SCRIPT_DIR/../shared/functions.sh"
+
 FORCE=false
 HELP=false
 
@@ -73,14 +77,18 @@ CONFIG_CONTENT="# Machine-Specific Git Configuration (macOS)
 	excludesfile = $HOME_DIR/.gitignore_global
 "
 
+SIGNING_ENABLED=false
 if [ -n "$OP_SSH_SIGN" ]; then
     echo "[INFO] Detected 1Password SSH signing helper: $OP_SSH_SIGN"
+    SIGNING_ENABLED=true
     CONFIG_CONTENT+="
 [gpg]
 	format = ssh
 
 [gpg \"ssh\"]
 	program = $OP_SSH_SIGN
+	# Lets git verify SSH commit signatures locally (git log --show-signature)
+	allowedSignersFile = $HOME_DIR/.ssh/allowed_signers
 
 [commit]
 	gpgsign = true
@@ -110,5 +118,13 @@ CONFIG_CONTENT+="
 printf '%s\n' "$CONFIG_CONTENT" > "$LOCAL_CONFIG_PATH"
 echo "[OK] Created .gitconfig.local"
 echo ""
+
+# When signing is enabled, register the signing identity so git can verify
+# SSH commit signatures locally.
+if [ "$SIGNING_ENABLED" = true ]; then
+    update_allowed_signers "$HOME_DIR/.ssh/allowed_signers"
+    echo ""
+fi
+
 echo "To add safe directories, edit: $LOCAL_CONFIG_PATH"
 echo ""

--- a/scripts/shared/functions.sh
+++ b/scripts/shared/functions.sh
@@ -129,6 +129,63 @@ create_symlink() {
     fi
 }
 
+# Upsert the current signing identity into an allowed_signers file so git can
+# verify SSH commit signatures locally. Without it, `git log --show-signature`
+# and `git verify-commit` report "No signature" even though commits are signed.
+# Reads the signing key and email from git config. Idempotent: re-running does not
+# duplicate the line, and entries for other identities are preserved.
+# Usage: update_allowed_signers ALLOWED_SIGNERS_PATH
+update_allowed_signers() {
+    local allowed_signers_path="$1"
+    local signing_key signer_email raw_key pub_key candidate ssh_dir line
+
+    # `|| true` keeps `set -e` from aborting when a key is unset (git config
+    # --get exits non-zero); the empty-check below handles it gracefully.
+    signing_key="$(git config --get user.signingkey 2>/dev/null || true)"
+    signer_email="$(git config --get user.email 2>/dev/null || true)"
+
+    if [ -z "$signing_key" ] || [ -z "$signer_email" ]; then
+        echo "[WARN] No user.signingkey/user.email configured; skipped allowed_signers"
+        return 0
+    fi
+
+    # Resolve the public key: either the literal key (1Password) or a *.pub file
+    # (file-based signing key path).
+    case "$signing_key" in
+        ssh-*|sk-ssh-*|ecdsa-*)
+            raw_key="$signing_key"
+            ;;
+        *)
+            candidate="$signing_key"
+            case "$candidate" in
+                *.pub) ;;
+                *) candidate="$candidate.pub" ;;
+            esac
+            [ -f "$candidate" ] && raw_key="$(cat "$candidate")"
+            ;;
+    esac
+
+    if [ -z "$raw_key" ]; then
+        echo "[WARN] Could not resolve signing public key; skipped allowed_signers"
+        return 0
+    fi
+
+    # Normalize to "<keytype> <base64>" — drop any trailing comment.
+    pub_key="$(printf '%s' "$raw_key" | awk '{print $1" "$2}')"
+
+    ssh_dir="$(dirname "$allowed_signers_path")"
+    [ -d "$ssh_dir" ] || mkdir -p "$ssh_dir"
+    chmod 700 "$ssh_dir" 2>/dev/null || true
+
+    line="$signer_email namespaces=\"git\" $pub_key"
+    if [ -f "$allowed_signers_path" ] && grep -qF -- "$line" "$allowed_signers_path"; then
+        echo "[OK] allowed_signers already up to date"
+    else
+        printf '%s\n' "$line" >> "$allowed_signers_path"
+        echo "[OK] Updated $allowed_signers_path"
+    fi
+}
+
 # Set git global core.excludesfile to HOME_DIR/.gitignore_global
 # Usage: configure_global_gitignore HOME_DIR
 configure_global_gitignore() {

--- a/scripts/windows version/Initialize-LocalConfig.ps1
+++ b/scripts/windows version/Initialize-LocalConfig.ps1
@@ -39,6 +39,64 @@ SAFE DIRECTORIES:
     exit 0
 }
 
+function Update-AllowedSigners {
+    # Upserts the current signing identity into ~/.ssh/allowed_signers so git can
+    # verify SSH commit signatures locally. Reads the signing key and email from
+    # the already-generated ~/.gitconfig (git config). Idempotent: re-running does
+    # not duplicate the line, and existing entries for other identities are kept.
+    param([Parameter(Mandatory)][string]$AllowedSignersPath)
+
+    $signingKey = (& git config --get user.signingkey 2>$null)
+    $signerEmail = (& git config --get user.email 2>$null)
+
+    if ([string]::IsNullOrWhiteSpace($signingKey) -or [string]::IsNullOrWhiteSpace($signerEmail)) {
+        Write-Host "[WARN] No user.signingkey/user.email configured; skipped allowed_signers" -ForegroundColor Yellow
+        return
+    }
+
+    # Resolve the public key: either the literal key (1Password) or a *.pub file.
+    $pubKey = $null
+    if ($signingKey -match '^(ssh-|sk-ssh-|ecdsa-)') {
+        $pubKey = $signingKey.Trim()
+    }
+    else {
+        $candidate = if ($signingKey -match '\.pub$') { $signingKey } else { "$signingKey.pub" }
+        if (Test-Path $candidate) {
+            $pubKey = (Get-Content $candidate -Raw).Trim()
+        }
+    }
+
+    if ([string]::IsNullOrWhiteSpace($pubKey)) {
+        Write-Host "[WARN] Could not resolve signing public key; skipped allowed_signers" -ForegroundColor Yellow
+        return
+    }
+
+    # Normalize to "<keytype> <base64>" - drop any trailing comment so the line is
+    # valid allowed_signers syntax.
+    $parts = $pubKey -split '\s+'
+    if ($parts.Count -ge 2) {
+        $pubKey = "$($parts[0]) $($parts[1])"
+    }
+
+    $sshDir = Split-Path -Parent $AllowedSignersPath
+    if (-not (Test-Path $sshDir)) {
+        New-Item -ItemType Directory -Path $sshDir -Force | Out-Null
+    }
+
+    $line = "$signerEmail namespaces=`"git`" $pubKey"
+    $existing = @()
+    if (Test-Path $AllowedSignersPath) {
+        $existing = @(Get-Content $AllowedSignersPath)
+    }
+    if ($existing -contains $line) {
+        Write-Host "[OK] allowed_signers already up to date" -ForegroundColor Green
+    }
+    else {
+        Add-Content -Path $AllowedSignersPath -Value $line
+        Write-Host "[OK] Updated $AllowedSignersPath" -ForegroundColor Green
+    }
+}
+
 $homeDir = $env:USERPROFILE
 $localConfigPath = "$homeDir\.gitconfig.local"
 
@@ -70,6 +128,8 @@ try {
 [gpg "ssh"]
 	# Machine-specific SSH signing program path
 	program = $($homeDir -replace '\\', '/')/AppData/Local/Microsoft/WindowsApps/op-ssh-sign.exe
+	# Lets git verify SSH commit signatures locally (git log --show-signature, verify-commit)
+	allowedSignersFile = $($homeDir -replace '\\', '/')/.ssh/allowed_signers
 
 [safe]
 	# Network locations (make sure these paths exist on this machine)
@@ -86,8 +146,17 @@ try {
     Set-Content -Path $localConfigPath -Value $configContent -Force
     Write-Host "[OK] Created .gitconfig.local" -ForegroundColor Green
     Write-Host ""
+
+    # Build ~/.ssh/allowed_signers so git can verify SSH commit signatures locally.
+    # Without this file, `git log --show-signature` and `git verify-commit` report
+    # "No signature" even though commits are signed (and GitHub shows Verified).
+    $allowedSignersPath = Join-Path $homeDir ".ssh\allowed_signers"
+    Update-AllowedSigners -AllowedSignersPath $allowedSignersPath
+
+    Write-Host ""
     Write-Host "Local configuration includes:" -ForegroundColor Cyan
     Write-Host "  - SSH signing program path (op-ssh-sign.exe)" -ForegroundColor Gray
+    Write-Host "  - Allowed signers file for local signature verification" -ForegroundColor Gray
     Write-Host "  - Network safe directories (10.210.3.10, KFWS9BDC01)" -ForegroundColor Gray
     Write-Host "  - Local development directories" -ForegroundColor Gray
     Write-Host ""

--- a/tests/Initialize-LocalConfig.Tests.ps1
+++ b/tests/Initialize-LocalConfig.Tests.ps1
@@ -1,0 +1,90 @@
+BeforeAll {
+    $script:repoRoot = Split-Path -Parent $PSScriptRoot
+    $script:scriptPath = Join-Path $script:repoRoot "scripts\windows version\Initialize-LocalConfig.ps1"
+}
+
+Describe "Initialize-LocalConfig.ps1" {
+
+    Context "allowed_signers generation" {
+        BeforeEach {
+            # Sandbox everything to TestDrive so the real ~/.gitconfig.local and
+            # ~/.ssh/allowed_signers are never touched. Redirect HOME/USERPROFILE
+            # and isolate git's global/system config to seeded sandbox files.
+            $script:sandbox = Join-Path $TestDrive ([guid]::NewGuid().ToString("N"))
+            New-Item -ItemType Directory -Path $script:sandbox -Force | Out-Null
+
+            $script:savedUserProfile = $env:USERPROFILE
+            $script:savedHome = $env:HOME
+            $script:savedGlobal = $env:GIT_CONFIG_GLOBAL
+            $script:savedSystem = $env:GIT_CONFIG_SYSTEM
+
+            $env:USERPROFILE = $script:sandbox
+            $env:HOME = $script:sandbox
+            $env:GIT_CONFIG_GLOBAL = Join-Path $script:sandbox ".gitconfig"
+            $env:GIT_CONFIG_SYSTEM = Join-Path $script:sandbox "no-system-config"
+
+            git config --global user.email "sandbox@example.com" 2>&1 | Out-Null
+            git config --global user.signingkey "ssh-ed25519 AAAASANDBOXKEY test-comment" 2>&1 | Out-Null
+        }
+
+        AfterEach {
+            $env:USERPROFILE = $script:savedUserProfile
+            $env:HOME = $script:savedHome
+            $env:GIT_CONFIG_GLOBAL = $script:savedGlobal
+            $env:GIT_CONFIG_SYSTEM = $script:savedSystem
+        }
+
+        It "Should write ~/.ssh/allowed_signers with the signing identity" {
+            Push-Location $script:sandbox
+            try { & $script:scriptPath -Force 2>&1 | Out-Null } finally { Pop-Location }
+
+            $allowed = Join-Path $script:sandbox ".ssh\allowed_signers"
+            $allowed | Should -Exist
+            $content = Get-Content $allowed -Raw
+            $content | Should -Match 'sandbox@example.com namespaces="git" ssh-ed25519 AAAASANDBOXKEY'
+        }
+
+        It "Should drop any trailing comment from the public key" {
+            Push-Location $script:sandbox
+            try { & $script:scriptPath -Force 2>&1 | Out-Null } finally { Pop-Location }
+
+            $content = Get-Content (Join-Path $script:sandbox ".ssh\allowed_signers") -Raw
+            $content | Should -Not -Match 'test-comment'
+        }
+
+        It "Should set allowedSignersFile in .gitconfig.local" {
+            Push-Location $script:sandbox
+            try { & $script:scriptPath -Force 2>&1 | Out-Null } finally { Pop-Location }
+
+            $local = Join-Path $script:sandbox ".gitconfig.local"
+            $local | Should -Exist
+            (Get-Content $local -Raw) | Should -Match 'allowedSignersFile\s*=\s*.*/\.ssh/allowed_signers'
+        }
+
+        It "Should not duplicate the entry when run twice" {
+            Push-Location $script:sandbox
+            try {
+                & $script:scriptPath -Force 2>&1 | Out-Null
+                & $script:scriptPath -Force 2>&1 | Out-Null
+            }
+            finally { Pop-Location }
+
+            $allowed = Join-Path $script:sandbox ".ssh\allowed_signers"
+            @(Get-Content $allowed | Where-Object { $_ -match 'sandbox@example.com' }).Count | Should -Be 1
+        }
+
+        It "Should preserve entries for other identities" {
+            $sshDir = Join-Path $script:sandbox ".ssh"
+            New-Item -ItemType Directory -Path $sshDir -Force | Out-Null
+            $allowed = Join-Path $sshDir "allowed_signers"
+            Set-Content -Path $allowed -Value 'other@example.com namespaces="git" ssh-ed25519 AAAAOTHER'
+
+            Push-Location $script:sandbox
+            try { & $script:scriptPath -Force 2>&1 | Out-Null } finally { Pop-Location }
+
+            $content = Get-Content $allowed -Raw
+            $content | Should -Match 'other@example.com'
+            $content | Should -Match 'sandbox@example.com'
+        }
+    }
+}


### PR DESCRIPTION
Fixes #97

## Problem

Commits are signed correctly (1Password on Windows/macOS, file-based key on Linux) and show as Verified on GitHub, but local verification fails:

```
git log --show-signature
error: gpg.ssh.allowedSignersFile needs to be configured and exist for ssh signature verification
...
No signature
```

`gpg.ssh.allowedSignersFile` was never configured, so `git log --show-signature` / `git verify-commit` couldn't validate SSH signatures locally.

## Fix

Setup now generates `~/.ssh/allowed_signers` and points `gpg.ssh.allowedSignersFile` at it (written into the machine-specific `~/.gitconfig.local`). Done across all three platforms:

- **Windows** (`Initialize-LocalConfig.ps1`): new `Update-AllowedSigners` function; reads `user.signingkey` (1Password literal pubkey) + `user.email` from git config.
- **macOS / Linux** (`initialize-local-config.sh`): source a shared `update_allowed_signers` helper; only runs when signing is enabled. Linux resolves the `*.pub` of the configured key path.
- **Shared** (`scripts/shared/functions.sh`): `update_allowed_signers` — idempotent upsert, drops trailing key comments, preserves entries for other identities, and uses `|| true` so `set -e` doesn't abort when keys are unset.

The generated entry uses the standard format and is scoped to git:

```
you@example.com namespaces="git" ssh-ed25519 AAAA...
```

## Testing

```powershell
Invoke-Pester -Path "tests\Initialize-LocalConfig.Tests.ps1"   # 5/5 pass
```

- New sandboxed Pester guard (`tests/Initialize-LocalConfig.Tests.ps1`) redirects HOME/USERPROFILE and isolates git config to `TestDrive` — never touches the real `~`. Covers: writes the entry, drops trailing comments, sets `allowedSignersFile`, idempotent re-run, preserves other identities.
- Bash `update_allowed_signers` unit-tested across literal key, file-based key path, no-key (graceful skip under `set -e`), and multi-identity cases.
- `bash -n` clean on all three bash scripts; Windows `.ps1` verified ASCII-only (PS 5.1 guard).

## Notes

Two **pre-existing**, unrelated test failures remain on `main` (confirmed by stashing this branch and re-running): `Integration.Tests.ps1` "git branches alias ... semicolons" and `Initialize-GitConfig.Tests.ps1` "Generated config should contain absolute paths" — both are test-vs-template drift from the earlier `py`-launcher alias change (#92). Out of scope here; flagging separately.