### PR TITLE
feat: give the claude-skills aliases their own category

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,11 @@ git prs            # Show the status of your pull requests
 ```bash
 git localconfig          # Edit machine-specific git config (~/.gitconfig.local)
 git selfupdate           # Pull this repo and reinstall ~/.gitconfig from the template
+```
+
+**Claude Skills**
+
+```bash
 git skill-sync           # Sync the claude-skills repo (~/.claude/skills) with pull --ff-only
 git skill-publish        # Publish new/edited skills via a PR (prompts for a message, auto-merges)
 ```

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -53,8 +53,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   on their next update without a manual `pip install`
   ([#102](https://github.com/J-MaFf/gitconfig/issues/102))
 - The static `git alias` table is now grouped by category (Inspect, Commit, Branch &
-  Sync, GitHub, Maintenance) with a dedicated Category column, and curated descriptions
-  for every built-in alias ([#102](https://github.com/J-MaFf/gitconfig/issues/102))
+  Sync, GitHub, Maintenance, Claude Skills) with a dedicated Category column, and
+  curated descriptions for every built-in alias. The claude-skills aliases
+  (`skill-sync`, `skill-publish`) get their own "Claude Skills" category
+  ([#102](https://github.com/J-MaFf/gitconfig/issues/102))
 - The auto-update job (`git selfupdate` and the login-triggered run) now **prunes
   merged branches** instead of recreating them. It fetches with `--prune` to drop
   stale remote-tracking refs and deletes local branches whose upstream remote was

--- a/gitconfig_helper.py
+++ b/gitconfig_helper.py
@@ -189,7 +189,7 @@ def cleanup_branches(force=False):
 
 # Category ordering for the alias table and the interactive browser's tabs.
 # Aliases without an ALIAS_METADATA entry fall into "Other".
-CATEGORY_ORDER = ["Inspect", "Commit", "Branch & Sync", "GitHub", "Maintenance", "Other"]
+CATEGORY_ORDER = ["Inspect", "Commit", "Branch & Sync", "GitHub", "Maintenance", "Claude Skills", "Other"]
 
 # name -> (category, description). Drives both the static grouped table and the
 # interactive browser. Keep each name and its description on a single source
@@ -223,8 +223,9 @@ ALIAS_METADATA = {
     # Maintenance
     "localconfig": ("Maintenance", "Edit machine-specific git config (~/.gitconfig.local)"),
     "selfupdate": ("Maintenance", "Pull this repo and reinstall ~/.gitconfig from the template"),
-    "skill-sync": ("Maintenance", "Sync the claude-skills repo (~/.claude/skills): pull --ff-only"),
-    "skill-publish": ("Maintenance", "Publish new/edited skills (~/.claude/skills) via a PR with auto-merge"),
+    # Claude Skills
+    "skill-sync": ("Claude Skills", "Sync the claude-skills repo (~/.claude/skills): pull --ff-only"),
+    "skill-publish": ("Claude Skills", "Publish new/edited skills (~/.claude/skills) via a PR with auto-merge"),
 }
 
 

--- a/tests/gitconfig_helper.Tests.ps1
+++ b/tests/gitconfig_helper.Tests.ps1
@@ -429,6 +429,8 @@ import gitconfig_helper
             $script:src | Should -Match '"pr":\s*\("GitHub"'
             $script:src | Should -Match '"amend":\s*\("Commit"'
             $script:src | Should -Match '"s":\s*\("Inspect"'
+            $script:src | Should -Match '"skill-sync":\s*\("Claude Skills"'
+            $script:src | Should -Match '"skill-publish":\s*\("Claude Skills"'
         }
 
         It "get_git_aliases returns (name, description, category) tuples" {


### PR DESCRIPTION
Fixes #104

Follow-up to #102 / #103. `skill-sync` and `skill-publish` were grouped under **Maintenance**; this gives the claude-skills aliases their own **Claude Skills** category — a separate group in the static `git alias` table and a dedicated tab in the interactive browser.

## Changes
- `gitconfig_helper.py`: add `Claude Skills` to `CATEGORY_ORDER` (between Maintenance and Other) and retag `skill-sync` / `skill-publish` in `ALIAS_METADATA`.
- `README.md`: split the Maintenance usage block, adding a Claude Skills subsection.
- `docs/CHANGELOG.md`: note the new category.
- `tests/gitconfig_helper.Tests.ps1`: assert both skill aliases map to `Claude Skills`.

## Testing
Verified locally: helper stays ASCII-only and `git alias --plain` renders a `Claude Skills` group containing `skill-sync` and `skill-publish`:

```
| Claude Skills | skill-publish | Publish new/edited skills (~/.claude/skills) via a PR with auto-merge |
|               | skill-sync    | Sync the claude-skills repo (~/.claude/skills): pull --ff-only        |
```