### PR TITLE
feat: alias browser row navigation + Ctrl-G prompt insertion

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,15 +79,37 @@ Removes: `~/.gitconfig`, `~/.gitignore_global` symlink, `~/gitconfig_helper.py` 
 
 ### Git Aliases
 
-`git alias` opens an **interactive, categorized browser**: arrow-key/clickable tabs
-per category and a search box that filters by alias name **or** description. It
-needs a terminal and the optional `textual` package; when piped, in scripts, or
-without `textual` it falls back to a static grouped table. Force the static table
+`git alias` opens an **interactive, categorized browser**: clickable/arrow-key tabs
+per category, a search box that filters by alias name **or** description, and a result
+table you move through with **up/down**. Press **Enter** (or click a row) to pick an
+alias. It needs a terminal and the optional `textual` package; when piped, in scripts,
+or without `textual` it falls back to a static grouped table. Force the static table
 with `git alias --plain`.
 
 ```bash
 git alias          # Browse all aliases (interactive in a terminal)
 git alias --plain  # Static grouped table (good for piping: git alias --plain | grep pr)
+```
+
+In the browser: type to search, up/down to move, Enter/click to select, Ctrl+Left/Right
+to switch category, Esc to clear the search (or quit), Ctrl+C to quit.
+
+**Insert an alias at your prompt — `Ctrl-G`**
+
+The installer adds a `Ctrl-G` keybinding to your shell (bash/zsh) and PowerShell profile.
+Press `Ctrl-G` at the prompt to open the browser; the alias you pick is typed onto your
+command line, ready to run or edit. A program launched by `git alias` can't type at your
+prompt itself, so this keybinding does the insertion — like fzf's `Ctrl-T`. Enable it
+manually by sourcing the matching widget:
+
+```bash
+# bash (~/.bashrc) or zsh (~/.zshrc)
+source /path/to/gitconfig/scripts/shell/git-alias-widget.bash   # or .zsh
+```
+
+```powershell
+# PowerShell ($PROFILE)
+. "C:\path\to\gitconfig\scripts\shell\git-alias-widget.ps1"
 ```
 
 **Inspect**

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `git alias` browser — **row navigation and prompt insertion**. Move through the
+  results with up/down; press Enter (or click a row) to pick an alias. A `Ctrl-G` shell
+  keybinding (bash `bind -x`, zsh ZLE widget, PowerShell PSReadLine) opens the browser
+  and inserts the chosen `git <alias>` onto your command line, fzf-style: the browser
+  emits the selection via `git alias --out <file>` and the keybinding inserts it (a
+  git-alias subprocess can't type at the prompt itself). Install scripts source the
+  matching widget (`scripts/shell/git-alias-widget.{bash,zsh,ps1}`) from your shell rc /
+  `$PROFILE` (idempotent, guarded block); cleanup scripts remove it
+  ([#106](https://github.com/J-MaFf/gitconfig/issues/106))
 - Interactive `git alias` browser — running `git alias` in a terminal now opens a
   categorized, searchable table (built with `textual`): one tab per category with
   arrow-key/clickable navigation and a search box that filters by alias name **or**

--- a/gitconfig_helper.py
+++ b/gitconfig_helper.py
@@ -649,14 +649,17 @@ def _build_alias_app(aliases):
         DataTable { height: 1fr; margin: 0 1; }
         """
         BINDINGS = [
+            ("enter", "select", "Insert at prompt"),
+            ("up", "cursor_up", "Up"),
+            ("down", "cursor_down", "Down"),
             ("ctrl+right", "next_tab", "Next category"),
             ("ctrl+left", "prev_tab", "Prev category"),
-            ("escape", "clear_search", "Clear search"),
-            ("q", "quit", "Quit"),
+            ("escape", "clear_or_quit", "Clear / quit"),
         ]
-        # Class-level default so handlers that may fire during mount (e.g. Tabs
+        # Class-level defaults so handlers that may fire during mount (e.g. Tabs
         # posting TabActivated before on_mount runs) never hit an unset attribute.
         _query = ""
+        _done = False
 
         def compose(self):
             yield Header()
@@ -676,7 +679,9 @@ def _build_alias_app(aliases):
             table = self.query_one("#table", DataTable)
             table.cursor_type = "row"
             table.add_columns("Alias", "Category", "Description")
-            self.query_one(Tabs).focus()
+            # Focus the search box so typing filters immediately; up/down still
+            # move the table's row cursor via the app-level bindings below.
+            self.query_one("#search", Input).focus()
             self._refresh()
 
         def _active_index(self):
@@ -712,7 +717,8 @@ def _build_alias_app(aliases):
                     table.add_row(name, category, description)
                     shown += 1
             self.sub_title = (
-                f"{shown} shown  -  ctrl+left/right: categories, type to search, q: quit"
+                f"{shown} shown  -  type: search  up/down: move  enter: insert  "
+                f"ctrl+left/right: category  esc: clear/quit"
             )
 
         def _shift_tab(self, delta):
@@ -726,16 +732,56 @@ def _build_alias_app(aliases):
         def action_prev_tab(self):
             self._shift_tab(-1)
 
-        def action_clear_search(self):
+        def action_cursor_down(self):
+            self.query_one("#table", DataTable).action_cursor_down()
+
+        def action_cursor_up(self):
+            self.query_one("#table", DataTable).action_cursor_up()
+
+        def action_clear_or_quit(self):
+            # Esc clears an active search; on an empty search it exits (no pick).
             search = self.query_one("#search", Input)
-            search.value = ""
-            self._query = ""
-            self._refresh()
+            if search.value:
+                search.value = ""
+                self._query = ""
+                self._refresh()
+            else:
+                self.exit(None)
+
+        def _selected_command(self):
+            table = self.query_one("#table", DataTable)
+            if table.row_count == 0:
+                return None
+            try:
+                row = table.get_row_at(table.cursor_row)
+            except Exception:
+                return None
+            # Row is [alias, category, description]; emit a runnable command.
+            return f"git {row[0]}" if row else None
+
+        def action_select(self):
+            self._choose()
+
+        def _choose(self):
+            if self._done:
+                return
+            command = self._selected_command()
+            if command:
+                self._done = True
+                self.exit(command)
 
         def on_input_changed(self, event):
             if event.input.id == "search":
                 self._query = event.value
                 self._refresh()
+
+        def on_input_submitted(self, event):
+            # Enter while the search box has focus selects the highlighted row.
+            self._choose()
+
+        def on_data_table_row_selected(self, event):
+            # Enter on the focused table, or a mouse click on a row.
+            self._choose()
 
         def on_tabs_tab_activated(self, event):
             self._refresh()
@@ -743,17 +789,30 @@ def _build_alias_app(aliases):
     return AliasBrowser()
 
 
-def _launch_alias_browser(aliases):
+def _launch_alias_browser(aliases, select_out=None):
     """Launch the interactive Textual alias browser.
 
     Returns True if the browser ran, False if Textual is unavailable or the UI
     could not start -- the caller then prints the static table instead.
+
+    On selection the app returns the chosen command (e.g. "git pr"). When
+    select_out is a path, that command is written there (for the shell keybinding
+    to insert at the prompt); otherwise it is printed to stdout.
     """
     try:
         app = _build_alias_app(aliases)
         if app is None:
             return False
-        app.run()
+        choice = app.run()
+        if choice:
+            if select_out:
+                try:
+                    with open(select_out, "w", encoding="utf-8") as handle:
+                        handle.write(choice)
+                except OSError:
+                    pass
+            else:
+                print(choice)
         return True
     except Exception:
         # An incompatible terminal (or any UI error) falls back to the static
@@ -761,25 +820,36 @@ def _launch_alias_browser(aliases):
         return False
 
 
-def print_aliases(force_plain=False):
+def print_aliases(force_plain=False, select_out=None):
     """Show git aliases.
 
     In an interactive terminal with Textual installed, this launches the
-    categorized, searchable browser. When output is piped, in CI, when --plain
-    is passed, or when Textual is unavailable, it falls back to a static grouped
-    table so 'git alias | grep ...' and scripts keep working.
+    categorized, searchable browser; selecting an alias (Enter/click) yields
+    "git <alias>", written to select_out (for the shell keybinding) or printed.
+    When output is piped, in CI, with --plain, or without Textual it falls back
+    to a static grouped table so 'git alias | grep ...' and scripts keep working
+    -- except in selection mode (select_out set), where it stays silent so the
+    keybinding inserts nothing.
     """
     aliases = get_git_aliases()
-    if not force_plain and sys.stdout.isatty() and _launch_alias_browser(aliases):
+    if not force_plain and sys.stdout.isatty() and _launch_alias_browser(
+        aliases, select_out=select_out
+    ):
         return
-    _print_aliases_table(aliases)
+    if select_out is None:
+        _print_aliases_table(aliases)
 
 
 if __name__ == "__main__":
     if len(sys.argv) > 1:
         function_name = sys.argv[1]
         if function_name == "print_aliases":
-            print_aliases(force_plain="--plain" in sys.argv)
+            select_out = None
+            if "--out" in sys.argv:
+                idx = sys.argv.index("--out")
+                if idx + 1 < len(sys.argv):
+                    select_out = sys.argv[idx + 1]
+            print_aliases(force_plain="--plain" in sys.argv, select_out=select_out)
         elif function_name == "start":
             issue_arg = sys.argv[2] if len(sys.argv) > 2 else None
             sys.exit(start_branch(issue_arg))

--- a/scripts/linux version/cleanup-gitconfig.sh
+++ b/scripts/linux version/cleanup-gitconfig.sh
@@ -70,6 +70,12 @@ echo "-----"
 backup_file "$HOME_DIR/.gitconfig.local" && ((REMOVED++)) || true
 echo ""
 
+# STEP 2b: Remove the git-alias browser keybinding from shell rc files
+echo "[STEP 2b] Removing git-alias browser keybinding..."
+echo "-----"
+disable_git_alias_widget "$HOME_DIR"
+echo ""
+
 # STEP 3: Remove cron job (Linux-specific)
 echo "[STEP 3] Removing cron job..."
 echo "-----"

--- a/scripts/linux version/install.sh
+++ b/scripts/linux version/install.sh
@@ -176,6 +176,12 @@ else
 fi
 echo ""
 
+# STEP 6b: Enable the interactive git-alias browser keybinding (Ctrl-G)
+echo "[STEP 6b] Enabling git-alias browser keybinding..."
+echo "-----"
+enable_git_alias_widget "$REPO_ROOT" "$HOME_DIR"
+echo ""
+
 # STEP 7: Verify setup
 echo "[STEP 7] Verifying setup..."
 echo "-----"

--- a/scripts/mac version/cleanup-gitconfig.sh
+++ b/scripts/mac version/cleanup-gitconfig.sh
@@ -72,6 +72,12 @@ echo "-----"
 backup_file "$HOME_DIR/.gitconfig.local" && ((REMOVED++)) || true
 echo ""
 
+# STEP 2b: Remove the git-alias browser keybinding from shell rc files
+echo "[STEP 2b] Removing git-alias browser keybinding..."
+echo "-----"
+disable_git_alias_widget "$HOME_DIR"
+echo ""
+
 # STEP 3: Remove launchd agent (macOS-specific)
 echo "[STEP 3] Removing launchd login agent..."
 echo "-----"

--- a/scripts/mac version/install.sh
+++ b/scripts/mac version/install.sh
@@ -216,6 +216,12 @@ else
 fi
 echo ""
 
+# STEP 6b: Enable the interactive git-alias browser keybinding (Ctrl-G)
+echo "[STEP 6b] Enabling git-alias browser keybinding..."
+echo "-----"
+enable_git_alias_widget "$REPO_ROOT" "$HOME_DIR"
+echo ""
+
 # STEP 7: Verify setup
 echo "[STEP 7] Verifying setup..."
 echo "-----"

--- a/scripts/shared/functions.sh
+++ b/scripts/shared/functions.sh
@@ -202,3 +202,57 @@ configure_global_gitignore() {
         echo "[WARN] .gitignore_global not found"
     fi
 }
+
+# Markers delimiting the git-alias browser keybinding block in a shell rc file.
+# Kept in one place so enable/disable stay in sync.
+GIT_ALIAS_WIDGET_BEGIN="# >>> gitconfig git-alias browser (Ctrl-G) >>>"
+GIT_ALIAS_WIDGET_END="# <<< gitconfig git-alias browser <<<"
+
+# Source the interactive git-alias browser keybinding (Ctrl-G) from the user's
+# shell rc files (~/.zshrc, ~/.bashrc). Idempotent: a guarded marker block is
+# added once per rc file. A non-existent rc is only created when it matches the
+# login shell, so we never spawn rc files for shells the user does not use.
+# Args: repo_root, home_dir
+enable_git_alias_widget() {
+    local repo_root="$1" home_dir="$2"
+    local current_shell; current_shell="$(basename "${SHELL:-}")"
+    local rc widget kind
+    for kind in zsh bash; do
+        rc="$home_dir/.${kind}rc"
+        widget="$repo_root/scripts/shell/git-alias-widget.$kind"
+        if [ ! -f "$rc" ]; then
+            [ "$current_shell" = "$kind" ] || continue
+            : > "$rc"
+        fi
+        if grep -qF "$GIT_ALIAS_WIDGET_BEGIN" "$rc" 2>/dev/null; then
+            echo "[OK] git-alias keybinding already enabled in $rc"
+            continue
+        fi
+        {
+            echo ""
+            echo "$GIT_ALIAS_WIDGET_BEGIN"
+            echo "[ -f \"$widget\" ] && source \"$widget\""
+            echo "$GIT_ALIAS_WIDGET_END"
+        } >> "$rc"
+        echo "[OK] Enabled git-alias keybinding (Ctrl-G) in $rc"
+    done
+}
+
+# Remove the git-alias browser keybinding block from the user's shell rc files.
+# Args: home_dir
+disable_git_alias_widget() {
+    local home_dir="$1"
+    local rc tmp
+    for rc in "$home_dir/.zshrc" "$home_dir/.bashrc"; do
+        [ -f "$rc" ] || continue
+        grep -qF "$GIT_ALIAS_WIDGET_BEGIN" "$rc" 2>/dev/null || continue
+        tmp="$(mktemp)" || continue
+        awk -v b="$GIT_ALIAS_WIDGET_BEGIN" -v e="$GIT_ALIAS_WIDGET_END" '
+            $0 == b { skip = 1 }
+            skip && $0 == e { skip = 0; next }
+            !skip { print }
+        ' "$rc" > "$tmp" && cat "$tmp" > "$rc"
+        rm -f "$tmp"
+        echo "[OK] Disabled git-alias keybinding in $rc"
+    done
+}

--- a/scripts/shell/git-alias-widget.bash
+++ b/scripts/shell/git-alias-widget.bash
@@ -1,0 +1,29 @@
+# git-alias browser keybinding for bash (Ctrl-G).
+#
+# Opens the interactive `git alias` browser; the alias you select (Enter or
+# click) is inserted onto the current command line, ready to run or edit.
+# A program launched by `git alias` runs in a subprocess and cannot type at the
+# prompt itself, so this readline widget does the insertion. Modeled on fzf.
+#
+# Enable by sourcing this file from ~/.bashrc:
+#   [ -f /path/to/gitconfig/scripts/shell/git-alias-widget.bash ] && \
+#     source /path/to/gitconfig/scripts/shell/git-alias-widget.bash
+
+__git_alias_insert() {
+    command -v git >/dev/null 2>&1 || return 0
+    local tmp selection
+    tmp=$(mktemp) || return 0
+    # UI renders on the terminal; the chosen "git <alias>" lands in $tmp.
+    git alias --out "$tmp" </dev/tty >/dev/tty 2>/dev/tty
+    selection=$(cat "$tmp" 2>/dev/null)
+    rm -f "$tmp"
+    [ -n "$selection" ] || return 0
+    # Insert at the cursor, then advance the cursor past the inserted text.
+    READLINE_LINE="${READLINE_LINE:0:$READLINE_POINT}${selection}${READLINE_LINE:$READLINE_POINT}"
+    READLINE_POINT=$((READLINE_POINT + ${#selection}))
+}
+
+# Bind only in interactive shells that support `bind -x`. Change \C-g to rebind.
+case $- in
+    *i*) bind -x '"\C-g": __git_alias_insert' 2>/dev/null ;;
+esac

--- a/scripts/shell/git-alias-widget.ps1
+++ b/scripts/shell/git-alias-widget.ps1
@@ -1,0 +1,29 @@
+# git-alias browser keybinding for PowerShell / PSReadLine (Ctrl-G).
+#
+# Opens the interactive `git alias` browser; the alias you select (Enter or
+# click) is inserted onto the current command line, ready to run or edit.
+# A program launched by `git alias` runs in a subprocess and cannot type at the
+# prompt itself, so this PSReadLine key handler does the insertion.
+#
+# Enable by dot-sourcing this file from your $PROFILE:
+#   . "C:\path\to\gitconfig\scripts\shell\git-alias-widget.ps1"
+
+if (Get-Module -ListAvailable -Name PSReadLine) {
+    Set-PSReadLineKeyHandler -Chord 'Ctrl+g' `
+        -BriefDescription 'GitAliasBrowser' `
+        -LongDescription 'Browse git aliases and insert the chosen command' `
+        -ScriptBlock {
+            $tmp = [System.IO.Path]::GetTempFileName()
+            try {
+                # UI renders on the terminal; the chosen "git <alias>" lands in $tmp.
+                git alias --out $tmp
+                $selection = (Get-Content -Raw -ErrorAction SilentlyContinue $tmp)
+            }
+            finally {
+                Remove-Item $tmp -ErrorAction SilentlyContinue
+            }
+            if ($selection) {
+                [Microsoft.PowerShell.PSConsoleReadLine]::Insert($selection.Trim())
+            }
+        }
+}

--- a/scripts/shell/git-alias-widget.zsh
+++ b/scripts/shell/git-alias-widget.zsh
@@ -1,0 +1,29 @@
+# git-alias browser keybinding for zsh (Ctrl-G).
+#
+# Opens the interactive `git alias` browser; the alias you select (Enter or
+# click) is inserted onto the current command line, ready to run or edit.
+# A program launched by `git alias` runs in a subprocess and cannot type at the
+# prompt itself, so this ZLE widget does the insertion. Modeled on fzf.
+#
+# Enable by sourcing this file from ~/.zshrc:
+#   [ -f /path/to/gitconfig/scripts/shell/git-alias-widget.zsh ] && \
+#     source /path/to/gitconfig/scripts/shell/git-alias-widget.zsh
+
+__git_alias_insert() {
+    command -v git >/dev/null 2>&1 || return 0
+    local tmp selection
+    tmp=$(mktemp) || return 0
+    # UI renders on the terminal; the chosen "git <alias>" lands in $tmp.
+    git alias --out "$tmp" </dev/tty >/dev/tty 2>/dev/tty
+    selection=$(cat "$tmp" 2>/dev/null)
+    command rm -f "$tmp"
+    if [[ -n "$selection" ]]; then
+        # Insert at the cursor (LBUFFER is the text left of the cursor).
+        LBUFFER+="$selection"
+    fi
+    # Repaint the prompt after the full-screen UI exits.
+    zle reset-prompt
+}
+
+zle -N __git_alias_insert
+bindkey '^g' __git_alias_insert  # Ctrl-G; change to rebind.

--- a/scripts/windows version/Cleanup-GitConfig.ps1
+++ b/scripts/windows version/Cleanup-GitConfig.ps1
@@ -131,6 +131,34 @@ else {
 
 Write-Host ""
 
+# STEP 2b: Remove the git-alias browser keybinding from the PowerShell profile
+Write-Host "[STEP 2b] Removing git-alias browser keybinding..." -ForegroundColor Cyan
+Write-Host "-----" -ForegroundColor Cyan
+try {
+    $beginMarker = "# >>> gitconfig git-alias browser (Ctrl-G) >>>"
+    $endMarker = "# <<< gitconfig git-alias browser <<<"
+    $profilePath = $PROFILE.CurrentUserAllHosts
+    if ((Test-Path $profilePath) -and ((Get-Content -Raw $profilePath).Contains($beginMarker))) {
+        $kept = New-Object System.Collections.Generic.List[string]
+        $skip = $false
+        foreach ($line in Get-Content $profilePath) {
+            if ($line -eq $beginMarker) { $skip = $true; continue }
+            if ($skip -and $line -eq $endMarker) { $skip = $false; continue }
+            if (-not $skip) { $kept.Add($line) }
+        }
+        Set-Content -Path $profilePath -Value $kept
+        Write-Host "[OK] Removed git-alias keybinding from profile" -ForegroundColor Green
+        $removed++
+    }
+    else {
+        Write-Host "[SKIP] git-alias keybinding not present" -ForegroundColor Yellow
+    }
+}
+catch {
+    Write-Host "[WARN] Could not remove git-alias keybinding: $($_.Exception.Message)" -ForegroundColor Yellow
+}
+Write-Host ""
+
 # STEP 3: Remove Scheduled Task
 Write-Host "[STEP 3] Removing scheduled task..." -ForegroundColor Cyan
 Write-Host "-----" -ForegroundColor Cyan

--- a/scripts/windows version/install.ps1
+++ b/scripts/windows version/install.ps1
@@ -196,6 +196,30 @@ else {
 }
 Write-Host ""
 
+# STEP 6b: Enable the interactive git-alias browser keybinding (Ctrl-G)
+Write-Host "[STEP 6b] Enabling git-alias browser keybinding..." -ForegroundColor Cyan
+Write-Host "-----" -ForegroundColor Cyan
+try {
+    $widgetPath = Join-Path $repoRoot "scripts\shell\git-alias-widget.ps1"
+    $beginMarker = "# >>> gitconfig git-alias browser (Ctrl-G) >>>"
+    $endMarker = "# <<< gitconfig git-alias browser <<<"
+    $profilePath = $PROFILE.CurrentUserAllHosts
+    $profileDir = Split-Path -Parent $profilePath
+    if (-not (Test-Path $profileDir)) { New-Item -ItemType Directory -Path $profileDir -Force | Out-Null }
+    $profileText = if (Test-Path $profilePath) { Get-Content -Raw $profilePath } else { "" }
+    if ($profileText -and $profileText.Contains($beginMarker)) {
+        Write-Host "[OK] git-alias keybinding already enabled in profile" -ForegroundColor Green
+    }
+    else {
+        Add-Content -Path $profilePath -Value "`r`n$beginMarker`r`n. `"$widgetPath`"`r`n$endMarker"
+        Write-Host "[OK] Enabled git-alias keybinding (Ctrl-G) in $profilePath" -ForegroundColor Green
+    }
+}
+catch {
+    Write-Host "[WARN] Could not enable git-alias keybinding: $($_.Exception.Message)" -ForegroundColor Yellow
+}
+Write-Host ""
+
 # STEP 7: Verify setup
 Write-Host "[STEP 7] Verifying setup..." -ForegroundColor Cyan
 Write-Host "-----" -ForegroundColor Cyan

--- a/tests/gitconfig_helper.Tests.ps1
+++ b/tests/gitconfig_helper.Tests.ps1
@@ -476,6 +476,67 @@ import gitconfig_helper
         It "Falls back to the static table when the browser is unavailable" {
             $script:src | Should -Match "def _print_aliases_table"
         }
+
+        It "Binds row navigation and selection keys" {
+            $script:src | Should -Match '\("enter", "select"'
+            $script:src | Should -Match '\("up", "cursor_up"'
+            $script:src | Should -Match '\("down", "cursor_down"'
+        }
+
+        It "Selects via Enter, a table row click, and emits a git command" {
+            $script:src | Should -Match "def _selected_command"
+            $script:src | Should -Match "def on_input_submitted"
+            $script:src | Should -Match "def on_data_table_row_selected"
+            $script:src | Should -Match 'return f"git \{row\[0\]\}"'
+        }
+
+        It "Supports --select output via --out wired through __main__" {
+            $script:src | Should -Match "select_out"
+            $script:src | Should -Match '"--out" in sys\.argv'
+        }
+
+        It "Stays silent in selection mode (no static table dumped to the tty)" {
+            # --out is the keybinding path; with no TTY the browser is skipped and
+            # nothing should be printed (so the shell inserts an empty selection).
+            $tmp = [System.IO.Path]::GetTempFileName()
+            try {
+                $result = & python $script:helperScript print_aliases --out $tmp 2>&1
+                $output = ($result -join "`n").Trim()
+                $output | Should -Not -Match "Git Aliases"
+                $LASTEXITCODE | Should -Be 0
+            }
+            finally {
+                Remove-Item $tmp -ErrorAction SilentlyContinue
+            }
+        }
+    }
+
+    Context "Ctrl-G shell keybinding widgets" {
+        It "Ships bash, zsh, and PowerShell widget files" {
+            foreach ($ext in @("bash", "zsh", "ps1")) {
+                Join-Path $script:repoRoot "scripts/shell/git-alias-widget.$ext" | Should -Exist
+            }
+        }
+
+        It "Widgets run the browser with --out and insert the result" {
+            $bash = Get-Content (Join-Path $script:repoRoot "scripts/shell/git-alias-widget.bash") -Raw
+            $bash | Should -Match 'git alias --out'
+            $bash | Should -Match 'READLINE_LINE'
+            $zsh = Get-Content (Join-Path $script:repoRoot "scripts/shell/git-alias-widget.zsh") -Raw
+            $zsh | Should -Match 'git alias --out'
+            $zsh | Should -Match 'LBUFFER'
+            $ps = Get-Content (Join-Path $script:repoRoot "scripts/shell/git-alias-widget.ps1") -Raw
+            $ps | Should -Match 'git alias --out'
+            $ps | Should -Match 'PSConsoleReadLine'
+        }
+
+        It "Install and cleanup wire the keybinding idempotently" {
+            $functions = Get-Content (Join-Path $script:repoRoot "scripts/shared/functions.sh") -Raw
+            $functions | Should -Match "enable_git_alias_widget"
+            $functions | Should -Match "disable_git_alias_widget"
+            $macInstall = Get-Content (Join-Path $script:repoRoot "scripts/mac version/install.sh") -Raw
+            $macInstall | Should -Match "enable_git_alias_widget"
+        }
     }
 
     Context "start Function (git start)" {


### PR DESCRIPTION
Fixes #106

Two enhancements to the interactive `git alias` browser (from #102).

## 1. Row navigation
The search box is focused on open (type filters immediately); **up/down** move the row cursor, fzf-style. `Esc` clears an active search, or exits when the search is empty.

## 2. Insert the selected alias at your prompt (Ctrl-G)
**Enter** (or a row **click**) selects the highlighted alias; the browser exits returning `git <alias>`.

A program launched by `git alias` runs in a subprocess and can't type at the parent prompt, so insertion is done by a **`Ctrl-G` shell keybinding** (modeled on fzf's `Ctrl-T`):

- The browser emits the selection via `git alias --out <file>` (UI on the tty, choice written to the file). In selection mode the static-table fallback is suppressed, so nothing leaks to the terminal.
- New widgets in `scripts/shell/`: **bash** (`bind -x` + `READLINE_LINE`), **zsh** (ZLE widget + `LBUFFER`), **PowerShell** (PSReadLine `Insert`). Each runs the browser and inserts the chosen command at the cursor.
- Install scripts wire it up idempotently: `enable_git_alias_widget` / `disable_git_alias_widget` in `scripts/shared/functions.sh` add/remove a guarded marker block in `~/.zshrc` / `~/.bashrc` (mac/linux STEP 6b / 2b) and `$PROFILE` (Windows STEP 6b / 2b).

## Keys
`type` search · `up/down` move · `Enter`/click insert · `Ctrl+Left/Right` category · `Esc` clear/quit · `Ctrl+C` quit

## Testing
- **Headless Textual pilot:** row nav (`down`x2 -> cursor row 2), Enter-select, search-then-select (`push` -> `git pushf`), `Esc` clear-then-quit -> no pick. All pass.
- **Launcher plumbing:** `--out` writes the choice to the file; no `--out` prints to stdout; no-pick writes nothing.
- **Widgets:** `bash -n` / `zsh -n` clean; `READLINE_LINE` splice and `LBUFFER` append verified.
- **Install wiring:** `enable`/`disable` round-trip on a fake `HOME` — idempotent, shell-aware (won't spawn an rc for an unused shell), clean removal.
- **Silent selection mode:** `git alias --out <tmp>` in a non-tty prints nothing and exits 0.
- Helper stays ASCII-only; `git alias --plain` and piping unaffected.

```bash
git alias            # browse; up/down to move, Enter to pick
# After install, at your shell prompt:
# press Ctrl-G  ->  pick an alias  ->  it's typed onto your command line
```

Note: the interactive Ctrl-G keybinding itself (terminal line-editor integration) is validated by syntax + logic checks and the headless pilot; it can't be exercised end-to-end in a non-interactive CI shell.