### PR TITLE
feat: copy selected alias to clipboard when git alias is typed

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,11 @@ git alias --plain  # Static grouped table (good for piping: git alias --plain | 
 In the browser: type to search, up/down to move, Enter/click to select, Ctrl+Left/Right
 to switch category, Esc to clear the search (or quit), Ctrl+C to quit.
 
+When you open the browser by **typing `git alias`**, selecting an alias copies `git <alias>`
+to your clipboard (paste with Cmd/Ctrl-V) — a typed `git alias` runs as a subprocess and
+can't type at your prompt. To have it inserted at the prompt directly, open the browser
+with the **`Ctrl-G`** keybinding instead.
+
 **Insert an alias at your prompt — `Ctrl-G`**
 
 The installer adds a `Ctrl-G` keybinding to your shell (bash/zsh) and PowerShell profile.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `git alias` browser — selecting an alias when launched by **typing `git alias`** now
+  copies `git <alias>` to the clipboard (`pbcopy` / `clip` / `wl-copy` / `xclip` / `xsel`,
+  with a printed fallback), so the command is one paste away. A typed `git alias` runs as
+  a subprocess and can't insert at the prompt; the `Ctrl-G` keybinding still does direct
+  insertion ([#108](https://github.com/J-MaFf/gitconfig/issues/108))
 - `git alias` browser — **row navigation and prompt insertion**. Move through the
   results with up/down; press Enter (or click a row) to pick an alias. A `Ctrl-G` shell
   keybinding (bash `bind -x`, zsh ZLE widget, PowerShell PSReadLine) opens the browser

--- a/gitconfig_helper.py
+++ b/gitconfig_helper.py
@@ -790,6 +790,35 @@ def _build_alias_app(aliases):
     return AliasBrowser()
 
 
+def _copy_to_clipboard(text):
+    """Copy text to the system clipboard.
+
+    Returns True on success, False if no clipboard tool is available or the copy
+    failed. Tries the native tool per platform: pbcopy (macOS), clip (Windows),
+    and wl-copy / xclip / xsel (Linux/Wayland/X11).
+    """
+    if sys.platform == "darwin":
+        candidates = [["pbcopy"]]
+    elif os.name == "nt":
+        candidates = [["clip"]]
+    else:
+        candidates = [
+            ["wl-copy"],
+            ["xclip", "-selection", "clipboard"],
+            ["xsel", "--clipboard", "--input"],
+        ]
+    for cmd in candidates:
+        if not _have(cmd[0]):
+            continue
+        try:
+            result = subprocess.run(cmd, input=text, text=True, capture_output=True)
+            if result.returncode == 0:
+                return True
+        except OSError:
+            continue
+    return False
+
+
 def _launch_alias_browser(aliases, select_out=None):
     """Launch the interactive Textual alias browser.
 
@@ -797,8 +826,10 @@ def _launch_alias_browser(aliases, select_out=None):
     could not start -- the caller then prints the static table instead.
 
     On selection the app returns the chosen command (e.g. "git pr"). When
-    select_out is a path, that command is written there (for the shell keybinding
-    to insert at the prompt); otherwise it is printed to stdout.
+    select_out is a path, that command is written there (for the Ctrl-G shell
+    keybinding to insert at the prompt). Otherwise -- i.e. when the browser was
+    launched by typing `git alias` -- the subprocess can't reach the prompt, so
+    the command is copied to the clipboard (with a printed fallback).
     """
     try:
         app = _build_alias_app(aliases)
@@ -813,7 +844,17 @@ def _launch_alias_browser(aliases, select_out=None):
                 except OSError:
                     pass
             else:
-                print(choice)
+                console = Console()
+                if _copy_to_clipboard(choice):
+                    console.print(
+                        f"[green]Copied to clipboard:[/green] [bold]{choice}[/bold]  "
+                        f"[dim](paste with Cmd/Ctrl-V; Ctrl-G inserts at the prompt)[/dim]"
+                    )
+                else:
+                    console.print(
+                        f"[cyan]{choice}[/cyan]  "
+                        f"[dim](copy it, or use Ctrl-G to insert at the prompt)[/dim]"
+                    )
         return True
     except Exception:
         # An incompatible terminal (or any UI error) falls back to the static
@@ -826,7 +867,8 @@ def print_aliases(force_plain=False, select_out=None):
 
     In an interactive terminal with Textual installed, this launches the
     categorized, searchable browser; selecting an alias (Enter/click) yields
-    "git <alias>", written to select_out (for the shell keybinding) or printed.
+    "git <alias>", written to select_out (for the Ctrl-G keybinding) or copied
+    to the clipboard when launched by typing `git alias`.
     When output is piped, in CI, with --plain, or without Textual it falls back
     to a static grouped table so 'git alias | grep ...' and scripts keep working
     -- except in selection mode (select_out set), where it stays silent so the

--- a/tests/gitconfig_helper.Tests.ps1
+++ b/tests/gitconfig_helper.Tests.ps1
@@ -497,6 +497,16 @@ import gitconfig_helper
             $script:src | Should -Match '"--out" in sys\.argv'
         }
 
+        It "Copies the selection to the clipboard when typed (no --out)" {
+            $script:src | Should -Match "def _copy_to_clipboard"
+            # Per-platform clipboard tools.
+            $script:src | Should -Match "pbcopy"
+            $script:src | Should -Match '"clip"'
+            $script:src | Should -Match "xclip"
+            # The typed-`git alias` path copies the choice rather than just printing it.
+            $script:src | Should -Match "_copy_to_clipboard\(choice\)"
+        }
+
         It "Stays silent in selection mode (no static table dumped to the tty)" {
             # --out is the keybinding path; with no TTY the browser is skipped and
             # nothing should be printed (so the shell inserts an empty selection).


### PR DESCRIPTION
Fixes #108

Follow-up to #106/#107. When the browser is opened by **typing `git alias`** (not via `Ctrl-G`), selecting an alias now **copies `git <alias>` to the clipboard** instead of printing it. A typed `git alias` runs as a subprocess and can't insert at the prompt — that's what `Ctrl-G` is for — so the clipboard is the useful "transfer" path.

## Changes
- `_copy_to_clipboard(text)` — `pbcopy` (macOS), `clip` (Windows), `wl-copy` / `xclip` / `xsel` (Linux); returns `False` if no tool is available.
- `_launch_alias_browser` — the no-`--out` path copies the choice and prints a short confirmation (`Copied to clipboard: git pr ...`), falling back to printing the command if the copy fails. The `--out` path (Ctrl-G) is unchanged.
- README + CHANGELOG document the typed-vs-Ctrl-G behavior.

## Behavior summary
| Launched via | On select |
|---|---|
| `Ctrl-G` keybinding | inserted at the prompt (unchanged) |
| typing `git alias` | copied to clipboard (new; was: printed) |
| piped / `--plain` / no Textual | static table (unchanged) |

## Testing
- `pbcopy` -> `pbpaste` round-trip of `_copy_to_clipboard`.
- Monkeypatched launcher: copies `git pr` and prints `Copied to clipboard` on the typed path; prints the command on the no-clipboard fallback; **never** touches the clipboard in `--out` mode (still writes the file).
- Helper stays ASCII-only; new Pester assertions cover the helper + copy-on-select path.