### PR TITLE
fix: move [include] to bottom of template so local signing key wins (#112)

### DIFF
--- a/.gitconfig.template
+++ b/.gitconfig.template
@@ -2,10 +2,6 @@
 # This file is used to generate ~/.gitconfig during setup
 # Placeholders: {{REPO_PATH}}, {{HOME_DIR}}
 
-# Include machine-specific configuration (local paths, safe directories, etc.)
-[include]
-	path = ~/.gitconfig.local
-
 # User identification - Customize for your own use
 [user]
 	name = Joey Maffiola
@@ -89,3 +85,10 @@
 
 [core]
 	editor = code --wait
+
+# Include machine-specific configuration (local paths, safe directories, etc.).
+# Kept LAST so values in ~/.gitconfig.local override the template's defaults
+# above (e.g. a file-based signingkey): git applies includes inline and the
+# last declaration of a key wins.
+[include]
+	path = ~/.gitconfig.local

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- `.gitconfig.template` — moved the `[include] path = ~/.gitconfig.local` directive to the
+  **bottom** of the template. Git applies includes inline and the last declaration of a key
+  wins, so with the include at the top the template's hardcoded literal `signingkey` silently
+  overrode whatever the local config set (e.g. the file-based key on Linux). The include now
+  runs last, so `~/.gitconfig.local` overrides take effect
+  ([#112](https://github.com/J-MaFf/gitconfig/issues/112))
+
 ### Added
 
 - `git alias` browser — when the interactive browser can't launch it no longer falls back


### PR DESCRIPTION
Fixes #112

## What changed
Moved the `[include] path = ~/.gitconfig.local` directive from the **top** of `.gitconfig.template` to the **bottom** (after `[core]`).

Git applies includes inline and the last declaration of a key wins. With the include at the top, the template's hardcoded literal `signingkey` (`ssh-ed25519 AAAA...`) silently overrode whatever `signingkey` the local config set — defeating the file-based key used on Linux/headless servers. With the include last, `~/.gitconfig.local` overrides take effect as intended.

## Testing / self-review
- Rendered the template with placeholder substitution and added a `~/.gitconfig.local` that sets `user.signingkey` to a file path.
- `git config --includes user.signingkey` resolves to the **local file path**, not the template literal — confirming the override now wins (it did not before this change).
- `git config --includes --list` parses the rendered config cleanly.
- Added a `### Fixed` entry to the `[Unreleased]` section of `docs/CHANGELOG.md`.