### PR TITLE
fix: normalize mixed tabs/spaces indentation in .gitconfig.template (#113)

### DIFF
--- a/.gitconfig.template
+++ b/.gitconfig.template
@@ -15,70 +15,70 @@
 	gpgsign = true
 
 [push]
-    autoSetupRemote = true
+	autoSetupRemote = true
 
 [alias]
-    # Browse all aliases: an interactive, categorized, searchable table when run
-    # in a terminal; pass --plain for a static grouped list (for piping/scripts).
-    alias = !"f() { for p in py python3 python; do command -v \"$p\" >/dev/null 2>&1 && \"$p\" -c '' >/dev/null 2>&1 && exec \"$p\" {{REPO_PATH}}/gitconfig_helper.py print_aliases \"$@\"; done; echo 'No working Python found (tried py, python3, python)' >&2; return 1; }; f"
-    # Download all remote branches creating local counterparts
-    branches = "!git fetch && git for-each-ref --format='%(refname:short)' refs/remotes/origin/ | grep -v -e '^origin/HEAD$' -e '^origin$' | while read ref; do git branch --track \"${ref#origin/}\" \"$ref\" 2>/dev/null || true; done"
-    cleanup = !"f() { for p in py python3 python; do command -v \"$p\" >/dev/null 2>&1 && \"$p\" -c '' >/dev/null 2>&1 && exec \"$p\" {{REPO_PATH}}/gitconfig_helper.py cleanup \"$@\"; done; echo 'No working Python found (tried py, python3, python)' >&2; return 1; }; f"
-    # Switch to main with error handling: fetch, check for uncommitted changes,
-    # checkout main, and pull. Detects and reports merge conflicts.
-    # Pass --all (or -a) to run this for every git repo in immediate subdirectories.
-    main = !"f() { for p in py python3 python; do command -v \"$p\" >/dev/null 2>&1 && \"$p\" -c '' >/dev/null 2>&1 && exec \"$p\" {{REPO_PATH}}/gitconfig_helper.py switch_to_main \"$@\"; done; echo 'No working Python found (tried py, python3, python)' >&2; return 1; }; f"
-    # Manage machine-specific git configuration
-    localconfig = !git config --file ~/.gitconfig.local
-    # Sync the claude-skills repo (~/.claude/skills) on demand, mirroring the
-    # auto-sync's --ff-only safety. Read-only; runs from any directory.
-    skill-sync = !git -C ~/.claude/skills pull --ff-only
-    # Publish new/edited skills in the claude-skills repo (~/.claude/skills) via a
-    # PR (its main is branch-protected): branches off main, prompts for a commit
-    # message, makes a signed commit, opens a PR, and enables squash auto-merge.
-    # Dispatches by OS like selfupdate; runs from any directory.
-    skill-publish = "!f() { case \"$(uname -s)\" in MINGW*|MSYS*|CYGWIN*) powershell -NoProfile -ExecutionPolicy Bypass -File \"$USERPROFILE\\.claude\\skills\\scripts\\publish-skill.ps1\" ;; *) bash \"$HOME/.claude/skills/scripts/publish-skill.sh\" ;; esac; }; f"
-    # Pull the latest gitconfig repo and reinstall ~/.gitconfig from the template
-    # on demand. Dispatches by OS: Git-for-Windows reports MINGW/MSYS/CYGWIN.
-    selfupdate = "!f() { case \"$(uname -s)\" in MINGW*|MSYS*|CYGWIN*) powershell -NoProfile -File '{{REPO_PATH}}/scripts/windows version/Update-GitConfig.ps1' -RepoPath '{{REPO_PATH}}' ;; *) bash '{{REPO_PATH}}/scripts/shared/update-gitconfig.sh' '{{REPO_PATH}}' ;; esac; }; f"
+	# Browse all aliases: an interactive, categorized, searchable table when run
+	# in a terminal; pass --plain for a static grouped list (for piping/scripts).
+	alias = !"f() { for p in py python3 python; do command -v \"$p\" >/dev/null 2>&1 && \"$p\" -c '' >/dev/null 2>&1 && exec \"$p\" {{REPO_PATH}}/gitconfig_helper.py print_aliases \"$@\"; done; echo 'No working Python found (tried py, python3, python)' >&2; return 1; }; f"
+	# Download all remote branches creating local counterparts
+	branches = "!git fetch && git for-each-ref --format='%(refname:short)' refs/remotes/origin/ | grep -v -e '^origin/HEAD$' -e '^origin$' | while read ref; do git branch --track \"${ref#origin/}\" \"$ref\" 2>/dev/null || true; done"
+	cleanup = !"f() { for p in py python3 python; do command -v \"$p\" >/dev/null 2>&1 && \"$p\" -c '' >/dev/null 2>&1 && exec \"$p\" {{REPO_PATH}}/gitconfig_helper.py cleanup \"$@\"; done; echo 'No working Python found (tried py, python3, python)' >&2; return 1; }; f"
+	# Switch to main with error handling: fetch, check for uncommitted changes,
+	# checkout main, and pull. Detects and reports merge conflicts.
+	# Pass --all (or -a) to run this for every git repo in immediate subdirectories.
+	main = !"f() { for p in py python3 python; do command -v \"$p\" >/dev/null 2>&1 && \"$p\" -c '' >/dev/null 2>&1 && exec \"$p\" {{REPO_PATH}}/gitconfig_helper.py switch_to_main \"$@\"; done; echo 'No working Python found (tried py, python3, python)' >&2; return 1; }; f"
+	# Manage machine-specific git configuration
+	localconfig = !git config --file ~/.gitconfig.local
+	# Sync the claude-skills repo (~/.claude/skills) on demand, mirroring the
+	# auto-sync's --ff-only safety. Read-only; runs from any directory.
+	skill-sync = !git -C ~/.claude/skills pull --ff-only
+	# Publish new/edited skills in the claude-skills repo (~/.claude/skills) via a
+	# PR (its main is branch-protected): branches off main, prompts for a commit
+	# message, makes a signed commit, opens a PR, and enables squash auto-merge.
+	# Dispatches by OS like selfupdate; runs from any directory.
+	skill-publish = "!f() { case \"$(uname -s)\" in MINGW*|MSYS*|CYGWIN*) powershell -NoProfile -ExecutionPolicy Bypass -File \"$USERPROFILE\\.claude\\skills\\scripts\\publish-skill.ps1\" ;; *) bash \"$HOME/.claude/skills/scripts/publish-skill.sh\" ;; esac; }; f"
+	# Pull the latest gitconfig repo and reinstall ~/.gitconfig from the template
+	# on demand. Dispatches by OS: Git-for-Windows reports MINGW/MSYS/CYGWIN.
+	selfupdate = "!f() { case \"$(uname -s)\" in MINGW*|MSYS*|CYGWIN*) powershell -NoProfile -File '{{REPO_PATH}}/scripts/windows version/Update-GitConfig.ps1' -RepoPath '{{REPO_PATH}}' ;; *) bash '{{REPO_PATH}}/scripts/shared/update-gitconfig.sh' '{{REPO_PATH}}' ;; esac; }; f"
 
-    # --- Inspect ---
-    # Short, branch-aware working-tree status
-    s = status -sb
-    # Pretty, decorated commit graph across all branches
-    lg = log --graph --oneline --decorate --all
-    # Show the most recent commit with its diffstat
-    last = log -1 HEAD --stat
-    # List local branches ordered by most recent commit
-    recent = for-each-ref --sort=-committerdate --count=15 --format='%(refname:short)' refs/heads/
-    # Find commits that added or removed a string: git find <string>
-    find = log -S
-    # --- Commit ---
-    # Fold staged changes into the last commit, keeping its message
-    amend = commit --amend --no-edit
-    # Edit the last commit's message (opens the editor)
-    reword = commit --amend
-    # Undo the last commit but keep its changes staged
-    undo = reset --soft HEAD~1
-    # Unstage files while keeping working-tree changes
-    unstage = reset HEAD --
-    # Park all current work as a WIP commit (skips hooks)
-    wip = !git add -A && git commit -m 'WIP' --no-verify
-    # --- Branch & Sync ---
-    # Create and switch to a new branch: git nb <name>
-    nb = switch -c
-    # Force-push the current branch safely (refuses to clobber others' work)
-    pushf = push --force-with-lease
-    # Update the current branch with rebase, stashing/restoring local changes
-    sync = pull --rebase --autostash
-    # Start work on a GitHub issue: create a conventionally named branch from its
-    # title (git start <issue-number>). Dispatches to the Python helper.
-    start = !"f() { for p in py python3 python; do command -v \"$p\" >/dev/null 2>&1 && \"$p\" -c '' >/dev/null 2>&1 && exec \"$p\" {{REPO_PATH}}/gitconfig_helper.py start \"$@\"; done; echo 'No working Python found (tried py, python3, python)' >&2; return 1; }; f"
-    # --- GitHub ---
-    # Open the current branch's pull request in the browser
-    pr = !gh pr view --web
-    # Show the status of your pull requests
-    prs = !gh pr status
+	# --- Inspect ---
+	# Short, branch-aware working-tree status
+	s = status -sb
+	# Pretty, decorated commit graph across all branches
+	lg = log --graph --oneline --decorate --all
+	# Show the most recent commit with its diffstat
+	last = log -1 HEAD --stat
+	# List local branches ordered by most recent commit
+	recent = for-each-ref --sort=-committerdate --count=15 --format='%(refname:short)' refs/heads/
+	# Find commits that added or removed a string: git find <string>
+	find = log -S
+	# --- Commit ---
+	# Fold staged changes into the last commit, keeping its message
+	amend = commit --amend --no-edit
+	# Edit the last commit's message (opens the editor)
+	reword = commit --amend
+	# Undo the last commit but keep its changes staged
+	undo = reset --soft HEAD~1
+	# Unstage files while keeping working-tree changes
+	unstage = reset HEAD --
+	# Park all current work as a WIP commit (skips hooks)
+	wip = !git add -A && git commit -m 'WIP' --no-verify
+	# --- Branch & Sync ---
+	# Create and switch to a new branch: git nb <name>
+	nb = switch -c
+	# Force-push the current branch safely (refuses to clobber others' work)
+	pushf = push --force-with-lease
+	# Update the current branch with rebase, stashing/restoring local changes
+	sync = pull --rebase --autostash
+	# Start work on a GitHub issue: create a conventionally named branch from its
+	# title (git start <issue-number>). Dispatches to the Python helper.
+	start = !"f() { for p in py python3 python; do command -v \"$p\" >/dev/null 2>&1 && \"$p\" -c '' >/dev/null 2>&1 && exec \"$p\" {{REPO_PATH}}/gitconfig_helper.py start \"$@\"; done; echo 'No working Python found (tried py, python3, python)' >&2; return 1; }; f"
+	# --- GitHub ---
+	# Open the current branch's pull request in the browser
+	pr = !gh pr view --web
+	# Show the status of your pull requests
+	prs = !gh pr status
 
 [init]
 	defaultBranch = main

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `.gitconfig.template` — normalized indentation to tabs throughout. The `[push]` and
+  `[alias]` sections used four-space indentation while every other section used tabs; git
+  accepts both but the inconsistency is fragile for any future formatter/validator. All
+  value/comment lines are now tab-indented ([#113](https://github.com/J-MaFf/gitconfig/issues/113))
+
 - `.gitconfig.template` — moved the `[include] path = ~/.gitconfig.local` directive to the
   **bottom** of the template. Git applies includes inline and the last declaration of a key
   wins, so with the include at the top the template's hardcoded literal `signingkey` silently


### PR DESCRIPTION
Fixes #113

## What changed
Converted the four-space-indented lines in the `[push]` and `[alias]` sections of `.gitconfig.template` to tabs, matching the rest of the file (which already used tabs for `[user]`, `[gpg]`, `[commit]`, `[include]`, etc.).

Git accepts both tabs and spaces, but the inconsistency is fragile for any future formatter/validator. All 61 indented lines now use a single leading tab.

## Testing / self-review
- Confirmed every space-indented line used exactly four leading spaces (single level) before conversion, so a leading-4-spaces → tab swap is lossless.
- After conversion: no leading-space indentation remains in the file.
- Rendered the template and ran `git config --list` — parses cleanly.
- Spot-checked values across both affected sections: `push.autoSetupRemote=true`, `alias.s=status -sb`, `alias.pushf=push --force-with-lease` — all unchanged.
- Added an `[Unreleased]` → `Fixed` entry to `docs/CHANGELOG.md`.