### PR TITLE
fix: stop double-logging in update-gitconfig.sh (#114)

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `scripts/shared/update-gitconfig.sh` — fixed every log line being written **twice**.
+  `log_message` piped through `tee -a "$LOG_FILE"` while the entire main block was already
+  redirected with `>> "$LOG_FILE" 2>&1`, so each line landed in the log once via `tee` and
+  again via the block redirect. The script runs headless under launchd/cron (no terminal),
+  so `log_message` now uses a plain `echo` and the block redirect is the single source of
+  truth ([#114](https://github.com/J-MaFf/gitconfig/issues/114))
+
 - `.gitconfig.template` — normalized indentation to tabs throughout. The `[push]` and
   `[alias]` sections used four-space indentation while every other section used tabs; git
   accepts both but the inconsistency is fragile for any future formatter/validator. All

--- a/scripts/shared/update-gitconfig.sh
+++ b/scripts/shared/update-gitconfig.sh
@@ -10,7 +10,12 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 log_message() {
     local timestamp
     timestamp=$(date '+%Y-%m-%d %H:%M:%S')
-    echo "[$timestamp] $1" | tee -a "$LOG_FILE"
+    # The whole main block below is redirected to "$LOG_FILE", so a plain echo
+    # already reaches the log. Using `tee -a "$LOG_FILE"` here would write the
+    # line a second time (once via tee, once via the block redirect). This runs
+    # headless under launchd/cron with no terminal attached, so the block
+    # redirect is the single source of truth for log output.
+    echo "[$timestamp] $1"
 }
 
 mkdir -p "$(dirname "$LOG_FILE")"


### PR DESCRIPTION
Fixes #114

## What changed
`log_message` piped its output through `tee -a "$LOG_FILE"` while the entire main block of the script is already redirected with `>> "$LOG_FILE" 2>&1`. Each log line was therefore appended to the log file **twice** — once by `tee`, once by the block redirect.

The script runs headless under launchd/cron with no terminal attached, so the `tee`-to-terminal half is useless. Dropped `tee` and made `log_message` a plain `echo`; the block redirect is now the single source of truth. This also keeps the direct output of `generate_gitconfig` (sourced from `functions.sh`) in the log, which the alternative fix (removing the block redirect) would have dropped.

## Testing / self-review
- `bash -n scripts/shared/update-gitconfig.sh` passes.
- Runtime harness reproducing the `{ log_message ...; } >> LOG` pattern: a marker line now appears **exactly once** in the log.
- Confirmed the old `tee` + block-redirect combo produced **2** copies of the same line (the bug).
- Added an `[Unreleased]` → `Fixed` entry to `docs/CHANGELOG.md`.