### PR TITLE
test: add bash/Python coverage for shared scripts (#115)

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -30,6 +30,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Cross-platform test coverage for the shared scripts. Until now every test was Pester
+  (Windows-only), leaving `scripts/shared/functions.sh` and `gitconfig_helper.py` untested
+  on the primary dev platforms. Added `tests/shared/functions.bats` (bats-core) covering
+  `backup_file`, `create_symlink`, `update_allowed_signers`, `generate_gitconfig`, and the
+  git-alias widget enable/disable, plus `tests/shared/test_gitconfig_helper.py` (pytest)
+  covering `_slugify`, `LABEL_PREFIX` selection, `_have`, `_default_branch`, and
+  `get_git_aliases` parsing. See `tests/shared/README.md` to run them
+  ([#115](https://github.com/J-MaFf/gitconfig/issues/115))
+
 - `git alias` browser — when the interactive browser can't launch it no longer falls back
   to the static table **silently**: it prints a one-line reason to stderr (only when stderr
   is a TTY, so pipes/CI stay clean) — e.g. `textual` not installed, stdout not a TTY, or a

--- a/tests/shared/README.md
+++ b/tests/shared/README.md
@@ -1,0 +1,36 @@
+# Shared-script tests (Linux / macOS)
+
+These suites cover the cross-platform bash and Python code that the mac and
+linux setup scripts depend on. They complement the Windows-only Pester suite in
+`../` so regressions on the primary dev platforms are caught.
+
+| Suite | Runner | Covers |
+| --- | --- | --- |
+| `functions.bats` | [bats-core](https://github.com/bats-core/bats-core) | `scripts/shared/functions.sh` — `backup_file`, `create_symlink`, `update_allowed_signers`, `generate_gitconfig`, git-alias widget enable/disable |
+| `test_gitconfig_helper.py` | [pytest](https://docs.pytest.org/) | `gitconfig_helper.py` — `_slugify`, `LABEL_PREFIX` selection, `_have`, `_default_branch`, `get_git_aliases` |
+
+## Running
+
+### Bash (bats)
+
+```sh
+# Install bats-core (one of):
+#   brew install bats-core            # macOS
+#   sudo apt-get install bats         # Debian/Ubuntu
+#   git clone https://github.com/bats-core/bats-core && ./bats-core/install.sh ~/.local
+bats tests/shared/functions.bats
+```
+
+The suite redirects `GIT_CONFIG_GLOBAL` / `GIT_CONFIG_SYSTEM` and works inside a
+`mktemp -d` sandbox, so it never touches your real `~/.gitconfig`,
+`~/.gitconfig.local`, `~/.ssh/allowed_signers`, or shell rc files.
+
+### Python (pytest)
+
+```sh
+python -m pip install pytest rich   # rich is gitconfig_helper.py's own dependency
+pytest tests/shared/test_gitconfig_helper.py
+```
+
+The pytest suite imports `gitconfig_helper.py` by path and monkeypatches
+`run_git`, so it needs neither a real repository nor network access.

--- a/tests/shared/functions.bats
+++ b/tests/shared/functions.bats
@@ -1,0 +1,224 @@
+#!/usr/bin/env bats
+#
+# Bats suite for scripts/shared/functions.sh — the bash utilities sourced by
+# the mac and linux gitconfig scripts. Complements the Windows-only Pester
+# suite so regressions on the primary dev platforms are caught.
+#
+# Run with:  bats tests/shared/functions.bats
+# Requires:  bats-core (https://github.com/bats-core/bats-core) and git.
+
+setup() {
+    REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)"
+    # shellcheck source=../../scripts/shared/functions.sh
+    source "$REPO_ROOT/scripts/shared/functions.sh"
+
+    TESTDIR="$(mktemp -d)"
+    HOME_DIR="$TESTDIR/home"
+    mkdir -p "$HOME_DIR"
+
+    # Isolate git config so update_allowed_signers reads only what we seed and
+    # never touches the developer's real ~/.gitconfig.
+    export GIT_CONFIG_GLOBAL="$TESTDIR/gitconfig-global"
+    export GIT_CONFIG_SYSTEM="$TESTDIR/no-system-config"
+    : > "$GIT_CONFIG_GLOBAL"
+}
+
+teardown() {
+    rm -rf "$TESTDIR"
+}
+
+# ---------------------------------------------------------------------------
+# backup_file
+# ---------------------------------------------------------------------------
+
+@test "backup_file moves an existing file to Existing.<name>.bak" {
+    echo "original" > "$TESTDIR/.gitconfig"
+    run backup_file "$TESTDIR/.gitconfig"
+    [ "$status" -eq 0 ]
+    [ ! -e "$TESTDIR/.gitconfig" ]
+    [ -f "$TESTDIR/Existing..gitconfig.bak" ]
+    [ "$(cat "$TESTDIR/Existing..gitconfig.bak")" = "original" ]
+}
+
+@test "backup_file returns 1 and skips when the target is missing" {
+    run backup_file "$TESTDIR/does-not-exist"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"[SKIP]"* ]]
+}
+
+@test "backup_file overwrites a stale backup instead of failing" {
+    echo "stale" > "$TESTDIR/Existing.file.bak"
+    echo "fresh" > "$TESTDIR/file"
+    run backup_file "$TESTDIR/file"
+    [ "$status" -eq 0 ]
+    [ "$(cat "$TESTDIR/Existing.file.bak")" = "fresh" ]
+}
+
+# ---------------------------------------------------------------------------
+# create_symlink
+# ---------------------------------------------------------------------------
+
+@test "create_symlink links source to destination" {
+    echo "src" > "$TESTDIR/source"
+    run create_symlink "$TESTDIR/source" "$TESTDIR/link" true
+    [ "$status" -eq 0 ]
+    [ -L "$TESTDIR/link" ]
+    [ "$(cat "$TESTDIR/link")" = "src" ]
+}
+
+@test "create_symlink errors when the source is missing" {
+    run create_symlink "$TESTDIR/missing" "$TESTDIR/link" true
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"[ERROR]"* ]]
+    [ ! -e "$TESTDIR/link" ]
+}
+
+@test "create_symlink backs up an existing destination with force=true" {
+    echo "src" > "$TESTDIR/source"
+    echo "old" > "$TESTDIR/link"
+    run create_symlink "$TESTDIR/source" "$TESTDIR/link" true
+    [ "$status" -eq 0 ]
+    [ -L "$TESTDIR/link" ]
+    [ -f "$TESTDIR/Existing.link.bak" ]
+    [ "$(cat "$TESTDIR/Existing.link.bak")" = "old" ]
+}
+
+# ---------------------------------------------------------------------------
+# update_allowed_signers  (the helper behind issue #116)
+# ---------------------------------------------------------------------------
+
+@test "update_allowed_signers writes the signing identity for a literal key" {
+    git config --global user.email "dev@example.com"
+    git config --global user.signingkey "ssh-ed25519 AAAATESTKEY a-comment"
+    local signers="$HOME_DIR/.ssh/allowed_signers"
+
+    run update_allowed_signers "$signers"
+    [ "$status" -eq 0 ]
+    [ -f "$signers" ]
+    # Email + git namespace + normalized "<type> <base64>" (comment dropped).
+    grep -qF 'dev@example.com namespaces="git" ssh-ed25519 AAAATESTKEY' "$signers"
+    ! grep -q 'a-comment' "$signers"
+}
+
+@test "update_allowed_signers is idempotent (no duplicate lines)" {
+    git config --global user.email "dev@example.com"
+    git config --global user.signingkey "ssh-ed25519 AAAATESTKEY a-comment"
+    local signers="$HOME_DIR/.ssh/allowed_signers"
+
+    update_allowed_signers "$signers"
+    update_allowed_signers "$signers"
+    [ "$(grep -c 'dev@example.com' "$signers")" -eq 1 ]
+}
+
+@test "update_allowed_signers resolves a file-based key from its .pub file" {
+    local keyfile="$HOME_DIR/.ssh/id_ed25519_signing"
+    mkdir -p "$HOME_DIR/.ssh"
+    echo "ssh-ed25519 AAAAFILEKEY host-comment" > "$keyfile.pub"
+    git config --global user.email "dev@example.com"
+    git config --global user.signingkey "$keyfile"
+    local signers="$HOME_DIR/.ssh/allowed_signers"
+
+    run update_allowed_signers "$signers"
+    [ "$status" -eq 0 ]
+    grep -qF 'dev@example.com namespaces="git" ssh-ed25519 AAAAFILEKEY' "$signers"
+}
+
+@test "update_allowed_signers skips gracefully when no signing key is set" {
+    git config --global user.email "dev@example.com"
+    local signers="$HOME_DIR/.ssh/allowed_signers"
+
+    run update_allowed_signers "$signers"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"[WARN]"* ]]
+    [ ! -f "$signers" ]
+}
+
+@test "update_allowed_signers preserves other identities already present" {
+    mkdir -p "$HOME_DIR/.ssh"
+    local signers="$HOME_DIR/.ssh/allowed_signers"
+    echo 'other@example.com namespaces="git" ssh-ed25519 AAAAOTHER' > "$signers"
+    git config --global user.email "dev@example.com"
+    git config --global user.signingkey "ssh-ed25519 AAAATESTKEY a-comment"
+
+    run update_allowed_signers "$signers"
+    [ "$status" -eq 0 ]
+    grep -qF 'other@example.com' "$signers"
+    grep -qF 'dev@example.com' "$signers"
+}
+
+# ---------------------------------------------------------------------------
+# generate_gitconfig
+# ---------------------------------------------------------------------------
+
+@test "generate_gitconfig substitutes placeholders and writes output" {
+    local repo="$TESTDIR/repo"
+    mkdir -p "$repo"
+    printf '[core]\n\trepo = {{REPO_PATH}}\n\thome = {{HOME_DIR}}\n' > "$repo/.gitconfig.template"
+
+    run generate_gitconfig "$repo" "$HOME_DIR" true
+    [ "$status" -eq 0 ]
+    [ -f "$HOME_DIR/.gitconfig" ]
+    grep -qF "repo = $repo" "$HOME_DIR/.gitconfig"
+    grep -qF "home = $HOME_DIR" "$HOME_DIR/.gitconfig"
+    ! grep -q '{{' "$HOME_DIR/.gitconfig"
+}
+
+@test "generate_gitconfig errors when the template is missing" {
+    local repo="$TESTDIR/repo-no-template"
+    mkdir -p "$repo"
+    run generate_gitconfig "$repo" "$HOME_DIR" true
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"[ERROR]"* ]]
+}
+
+@test "generate_gitconfig backs up an existing config when forced" {
+    local repo="$TESTDIR/repo"
+    mkdir -p "$repo"
+    printf '[core]\n\trepo = {{REPO_PATH}}\n' > "$repo/.gitconfig.template"
+    echo "prior" > "$HOME_DIR/.gitconfig"
+
+    run generate_gitconfig "$repo" "$HOME_DIR" true
+    [ "$status" -eq 0 ]
+    [ -f "$HOME_DIR/.gitconfig.bak" ]
+    [ "$(cat "$HOME_DIR/.gitconfig.bak")" = "prior" ]
+}
+
+# ---------------------------------------------------------------------------
+# enable_git_alias_widget / disable_git_alias_widget
+# ---------------------------------------------------------------------------
+
+@test "enable_git_alias_widget adds a guarded marker block to an existing rc" {
+    : > "$HOME_DIR/.bashrc"
+    : > "$HOME_DIR/.zshrc"
+    run enable_git_alias_widget "$REPO_ROOT" "$HOME_DIR"
+    [ "$status" -eq 0 ]
+    grep -qF "$GIT_ALIAS_WIDGET_BEGIN" "$HOME_DIR/.bashrc"
+    grep -qF "$GIT_ALIAS_WIDGET_END" "$HOME_DIR/.bashrc"
+    grep -qF "git-alias-widget.bash" "$HOME_DIR/.bashrc"
+}
+
+@test "enable_git_alias_widget is idempotent (single marker block)" {
+    : > "$HOME_DIR/.bashrc"
+    enable_git_alias_widget "$REPO_ROOT" "$HOME_DIR"
+    enable_git_alias_widget "$REPO_ROOT" "$HOME_DIR"
+    [ "$(grep -cF "$GIT_ALIAS_WIDGET_BEGIN" "$HOME_DIR/.bashrc")" -eq 1 ]
+}
+
+@test "disable_git_alias_widget removes the marker block it added" {
+    : > "$HOME_DIR/.bashrc"
+    enable_git_alias_widget "$REPO_ROOT" "$HOME_DIR"
+    run disable_git_alias_widget "$HOME_DIR"
+    [ "$status" -eq 0 ]
+    ! grep -qF "$GIT_ALIAS_WIDGET_BEGIN" "$HOME_DIR/.bashrc"
+    ! grep -qF "$GIT_ALIAS_WIDGET_END" "$HOME_DIR/.bashrc"
+}
+
+@test "disable_git_alias_widget preserves surrounding rc content" {
+    printf 'export FOO=1\n' > "$HOME_DIR/.bashrc"
+    enable_git_alias_widget "$REPO_ROOT" "$HOME_DIR"
+    printf 'export BAR=2\n' >> "$HOME_DIR/.bashrc"
+    disable_git_alias_widget "$HOME_DIR"
+    grep -qF 'export FOO=1' "$HOME_DIR/.bashrc"
+    grep -qF 'export BAR=2' "$HOME_DIR/.bashrc"
+    ! grep -qF "$GIT_ALIAS_WIDGET_BEGIN" "$HOME_DIR/.bashrc"
+}

--- a/tests/shared/test_gitconfig_helper.py
+++ b/tests/shared/test_gitconfig_helper.py
@@ -1,0 +1,203 @@
+# Pytest suite for the pure-logic helpers in gitconfig_helper.py.
+#
+# These run on the primary dev platforms (Linux/macOS), complementing the
+# Windows-only Pester suite. They exercise the deterministic, side-effect-free
+# parts of the helper (slugifying, label->prefix mapping, default-branch
+# resolution, alias parsing) so regressions are caught without needing a real
+# repository or network access.
+#
+# Run with:  pytest tests/shared/test_gitconfig_helper.py
+# Requires:  pytest and the helper's own dependency, `rich`.
+
+import importlib.util
+import os
+import sys
+
+import pytest
+
+REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
+HELPER_PATH = os.path.join(REPO_ROOT, "gitconfig_helper.py")
+
+
+def _load_helper():
+    """Import gitconfig_helper.py by path (it lives at the repo root, not on
+    sys.path, and is not a package)."""
+    spec = importlib.util.spec_from_file_location("gitconfig_helper", HELPER_PATH)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture(scope="module")
+def helper():
+    return _load_helper()
+
+
+# --------------------------------------------------------------------------
+# _slugify
+# --------------------------------------------------------------------------
+
+class TestSlugify:
+    def test_basic_title(self, helper):
+        assert helper._slugify("Add bash test coverage") == "add-bash-test-coverage"
+
+    def test_collapses_punctuation_and_spaces(self, helper):
+        assert helper._slugify("Fix:  the   bug!!!") == "fix-the-bug"
+
+    def test_strips_leading_and_trailing_separators(self, helper):
+        assert helper._slugify("  --Hello, World--  ") == "hello-world"
+
+    def test_lowercases(self, helper):
+        assert helper._slugify("CamelCase TITLE") == "camelcase-title"
+
+    def test_truncates_to_max_length_without_trailing_dash(self, helper):
+        title = "word " * 40  # far longer than the default 50-char cap
+        slug = helper._slugify(title)
+        assert len(slug) <= 50
+        assert not slug.endswith("-")
+
+    def test_custom_max_length(self, helper):
+        slug = helper._slugify("one two three four five", max_length=7)
+        assert len(slug) <= 7
+        assert not slug.endswith("-")
+
+    def test_empty_input_falls_back_to_issue(self, helper):
+        assert helper._slugify("") == "issue"
+
+    def test_punctuation_only_falls_back_to_issue(self, helper):
+        assert helper._slugify("!!!@@@###") == "issue"
+
+
+# --------------------------------------------------------------------------
+# LABEL_PREFIX  (drives the fix/feat/docs branch prefix in start_branch)
+# --------------------------------------------------------------------------
+
+class TestLabelPrefix:
+    def test_known_labels_map_to_expected_prefixes(self, helper):
+        assert helper.LABEL_PREFIX["bug"] == "fix"
+        assert helper.LABEL_PREFIX["enhancement"] == "feat"
+        assert helper.LABEL_PREFIX["feature"] == "feat"
+        assert helper.LABEL_PREFIX["documentation"] == "docs"
+        assert helper.LABEL_PREFIX["docs"] == "docs"
+
+    def test_first_matching_label_wins(self, helper):
+        # Mirrors the selection logic in start_branch: first label that is a
+        # known key determines the prefix, defaulting to "feat".
+        labels = ["wontfix", "bug", "enhancement"]
+        prefix = next(
+            (helper.LABEL_PREFIX[label] for label in labels if label in helper.LABEL_PREFIX),
+            "feat",
+        )
+        assert prefix == "fix"
+
+    def test_unknown_labels_default_to_feat(self, helper):
+        labels = ["question", "triage"]
+        prefix = next(
+            (helper.LABEL_PREFIX[label] for label in labels if label in helper.LABEL_PREFIX),
+            "feat",
+        )
+        assert prefix == "feat"
+
+
+# --------------------------------------------------------------------------
+# _have  (PATH lookup wrapper)
+# --------------------------------------------------------------------------
+
+class TestHave:
+    def test_returns_true_for_present_executable(self, helper):
+        # git is required for the whole project, so it is a safe positive.
+        assert helper._have("git") is True
+
+    def test_returns_false_for_absent_executable(self, helper):
+        assert helper._have("definitely-not-a-real-command-xyz") is False
+
+
+# --------------------------------------------------------------------------
+# _default_branch  (reads git config init.defaultBranch, falls back to main)
+# --------------------------------------------------------------------------
+
+class TestDefaultBranch:
+    def test_falls_back_to_main_when_unset(self, helper, monkeypatch):
+        class _Result:
+            returncode = 1
+            stdout = ""
+
+        monkeypatch.setattr(helper, "run_git", lambda *a, **k: _Result())
+        assert helper._default_branch() == "main"
+
+    def test_uses_configured_value(self, helper, monkeypatch):
+        class _Result:
+            returncode = 0
+            stdout = "trunk\n"
+
+        monkeypatch.setattr(helper, "run_git", lambda *a, **k: _Result())
+        assert helper._default_branch() == "trunk"
+
+
+# --------------------------------------------------------------------------
+# get_git_aliases  (parses `git config --get-regexp alias` output)
+# --------------------------------------------------------------------------
+
+class TestGetGitAliases:
+    def _patch_git_output(self, helper, monkeypatch, stdout, returncode=0):
+        class _Result:
+            pass
+
+        res = _Result()
+        res.returncode = returncode
+        res.stdout = stdout
+
+        def fake_run_git(*args, check=False):
+            if check and returncode != 0:
+                import subprocess
+
+                raise subprocess.CalledProcessError(returncode, args)
+            return res
+
+        monkeypatch.setattr(helper, "run_git", fake_run_git)
+
+    def test_known_alias_uses_curated_metadata(self, helper, monkeypatch):
+        self._patch_git_output(helper, monkeypatch, "alias.s status -sb\n")
+        aliases = helper.get_git_aliases()
+        assert len(aliases) == 1
+        name, description, category = aliases[0]
+        assert name == "s"
+        assert category == "Inspect"
+        # Curated description from ALIAS_METADATA, not the raw value.
+        assert description == helper.ALIAS_METADATA["s"][1]
+
+    def test_unknown_shell_alias_is_categorized_as_other(self, helper, monkeypatch):
+        self._patch_git_output(helper, monkeypatch, "alias.foo !echo hi\n")
+        aliases = helper.get_git_aliases()
+        assert len(aliases) == 1
+        name, description, category = aliases[0]
+        assert name == "foo"
+        assert category == "Other"
+        assert description.startswith("Shell: ")
+
+    def test_unknown_plain_alias_is_categorized_as_other(self, helper, monkeypatch):
+        self._patch_git_output(helper, monkeypatch, "alias.co checkout\n")
+        aliases = helper.get_git_aliases()
+        name, description, category = aliases[0]
+        assert name == "co"
+        assert category == "Other"
+        assert description == "checkout"
+
+    def test_results_sorted_by_category_then_name(self, helper, monkeypatch):
+        # "s" is Inspect (earlier in CATEGORY_ORDER), "zzz" is Other (last).
+        self._patch_git_output(helper, monkeypatch, "alias.zzz !echo z\nalias.s status -sb\n")
+        aliases = helper.get_git_aliases()
+        categories = [a[2] for a in aliases]
+        order = {c: i for i, c in enumerate(helper.CATEGORY_ORDER)}
+        assert [order[c] for c in categories] == sorted(order[c] for c in categories)
+        # Inspect ("s") must come before Other ("zzz").
+        assert aliases[0][0] == "s"
+
+    def test_empty_config_returns_empty_list(self, helper, monkeypatch):
+        # `git config --get-regexp alias` exits non-zero when no aliases exist.
+        self._patch_git_output(helper, monkeypatch, "", returncode=1)
+        assert helper.get_git_aliases() == []
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-v"]))


### PR DESCRIPTION
Fixes #115

## What changed
Every test in the repo was Pester (Windows-only), so `scripts/shared/functions.sh` and `gitconfig_helper.py` had no automated coverage on the primary dev platforms (Linux/macOS). This adds two suites under `tests/shared/`:

- **`functions.bats`** (bats-core) — covers `backup_file`, `create_symlink`, `update_allowed_signers` (literal key, `.pub`-file key, idempotency, no-key skip, preserving other identities), `generate_gitconfig` (placeholder substitution, missing-template error, backup-on-force), and the git-alias widget enable/disable (marker block, idempotency, surrounding-content preservation). Each test runs in a `mktemp` sandbox with `GIT_CONFIG_GLOBAL`/`SYSTEM` redirected, so it never touches the real `~/.gitconfig`, `~/.ssh/allowed_signers`, or shell rc files.
- **`test_gitconfig_helper.py`** (pytest) — covers `_slugify`, `LABEL_PREFIX` selection, `_have`, `_default_branch`, and `get_git_aliases` parsing. Imports the helper by path and monkeypatches `run_git`, so it needs no real repo or network.

Also adds `tests/shared/README.md` (run instructions) and a CHANGELOG `[Unreleased]` Added entry.

## Testing / self-review
- `pytest tests/shared/test_gitconfig_helper.py` → **20 passed**
- `bats tests/shared/functions.bats` → **18 passed** (run against a vendored bats-core 1.13.0, since bats isn't on the CI image)
- All tests exercise the real `functions.sh` / `gitconfig_helper.py` — no copied logic.
- No production code changed; this PR is test-only plus docs/CHANGELOG.