### PR TITLE
fix: always write allowedSignersFile on macOS when signing is enabled (#116)

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `scripts/mac version/initialize-local-config.sh` — always write `[gpg "ssh"]
+  allowedSignersFile` when commit signing is enabled, not only when 1Password's
+  `op-ssh-sign` is detected. The template ships a literal `signingkey` with
+  `commit.gpgsign = true`, so on a macOS box without 1Password the script wrote no
+  `allowedSignersFile` and `git log --show-signature` reported "No signature" for
+  perfectly valid signatures. It now mirrors the Linux script: when `op-ssh-sign` is
+  absent but a `user.signingkey` is configured (literal key or a file-based key), it
+  writes the `allowedSignersFile` block and registers the identity via
+  `update_allowed_signers`. With no key and no 1Password it still skips, as before
+  ([#116](https://github.com/J-MaFf/gitconfig/issues/116))
+
 - `scripts/shared/update-gitconfig.sh` — fixed every log line being written **twice**.
   `log_message` piped through `tee -a "$LOG_FILE"` while the entire main block was already
   redirected with `>> "$LOG_FILE" 2>&1`, so each line landed in the log once via `tee` and

--- a/scripts/mac version/initialize-local-config.sh
+++ b/scripts/mac version/initialize-local-config.sh
@@ -77,6 +77,14 @@ CONFIG_CONTENT="# Machine-Specific Git Configuration (macOS)
 	excludesfile = $HOME_DIR/.gitignore_global
 "
 
+# A signing key may already be configured in git even without 1Password — e.g.
+# the template ships a literal signingkey with commit.gpgsign=true, or a user
+# points user.signingkey at a file-based key. In all of those cases signing is
+# active, so allowedSignersFile must be written or git reports "No signature"
+# on verification. Mirror the Linux behavior: whenever signing is enabled, write
+# the [gpg "ssh"] allowedSignersFile block.
+EXISTING_SIGNING_KEY="$(git config --get user.signingkey 2>/dev/null || true)"
+
 SIGNING_ENABLED=false
 if [ -n "$OP_SSH_SIGN" ]; then
     echo "[INFO] Detected 1Password SSH signing helper: $OP_SSH_SIGN"
@@ -93,8 +101,24 @@ if [ -n "$OP_SSH_SIGN" ]; then
 [commit]
 	gpgsign = true
 "
+elif [ -n "$EXISTING_SIGNING_KEY" ]; then
+    # op-ssh-sign isn't installed, but a signing key is already configured
+    # (file-based key or a literal public key). Still write allowedSignersFile
+    # so signatures verify locally; omit the 1Password program line.
+    echo "[INFO] op-ssh-sign not found, but a signing key is configured:"
+    echo "       $EXISTING_SIGNING_KEY"
+    echo "       Writing allowedSignersFile so signatures verify locally."
+    SIGNING_ENABLED=true
+    CONFIG_CONTENT+="
+[gpg]
+	format = ssh
+
+[gpg \"ssh\"]
+	# Lets git verify SSH commit signatures locally (git log --show-signature)
+	allowedSignersFile = $HOME_DIR/.ssh/allowed_signers
+"
 else
-    echo "[INFO] op-ssh-sign not found — skipping SSH signing config."
+    echo "[INFO] op-ssh-sign not found and no signing key configured — skipping signing config."
     echo "       Install 1Password CLI via Homebrew to enable commit signing:"
     echo "         brew install 1password-cli"
     CONFIG_CONTENT+="

--- a/tests/shared/README.md
+++ b/tests/shared/README.md
@@ -7,6 +7,7 @@ linux setup scripts depend on. They complement the Windows-only Pester suite in
 | Suite | Runner | Covers |
 | --- | --- | --- |
 | `functions.bats` | [bats-core](https://github.com/bats-core/bats-core) | `scripts/shared/functions.sh` — `backup_file`, `create_symlink`, `update_allowed_signers`, `generate_gitconfig`, git-alias widget enable/disable |
+| `mac-initialize-local-config.bats` | bats-core | `scripts/mac version/initialize-local-config.sh` — always writes `allowedSignersFile` when signing is enabled ([#116](https://github.com/J-MaFf/gitconfig/issues/116)) |
 | `test_gitconfig_helper.py` | [pytest](https://docs.pytest.org/) | `gitconfig_helper.py` — `_slugify`, `LABEL_PREFIX` selection, `_have`, `_default_branch`, `get_git_aliases` |
 
 ## Running
@@ -18,7 +19,7 @@ linux setup scripts depend on. They complement the Windows-only Pester suite in
 #   brew install bats-core            # macOS
 #   sudo apt-get install bats         # Debian/Ubuntu
 #   git clone https://github.com/bats-core/bats-core && ./bats-core/install.sh ~/.local
-bats tests/shared/functions.bats
+bats tests/shared/        # runs every *.bats in this directory
 ```
 
 The suite redirects `GIT_CONFIG_GLOBAL` / `GIT_CONFIG_SYSTEM` and works inside a

--- a/tests/shared/mac-initialize-local-config.bats
+++ b/tests/shared/mac-initialize-local-config.bats
@@ -1,0 +1,81 @@
+#!/usr/bin/env bats
+#
+# Bats suite for scripts/mac version/initialize-local-config.sh, focused on the
+# allowedSignersFile behavior (issue #116): on macOS, allowedSignersFile must be
+# written whenever signing is enabled — not only when 1Password's op-ssh-sign is
+# installed. Otherwise `git log --show-signature` reports "No signature" for a
+# file-based or literal signing key.
+#
+# These tests run the real script in a mktemp sandbox with HOME and git config
+# redirected, so they never touch the developer's machine. op-ssh-sign is not on
+# the sandbox's fixed lookup paths (/opt/homebrew/bin, /usr/local/bin), so the
+# "no 1Password" branches are exercised naturally.
+#
+# Run with:  bats tests/shared/mac-initialize-local-config.bats
+# Requires:  bats-core and git.
+
+setup() {
+    REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)"
+    SCRIPT="$REPO_ROOT/scripts/mac version/initialize-local-config.sh"
+
+    SANDBOX="$(mktemp -d)"
+    export HOME="$SANDBOX"
+    export GIT_CONFIG_GLOBAL="$SANDBOX/.gitconfig"
+    export GIT_CONFIG_SYSTEM="$SANDBOX/no-system-config"
+    : > "$GIT_CONFIG_GLOBAL"
+}
+
+teardown() {
+    rm -rf "$SANDBOX"
+}
+
+@test "writes allowedSignersFile when a literal signing key is configured (no 1Password)" {
+    git config --global user.email "dev@example.com"
+    git config --global user.signingkey "ssh-ed25519 AAAALITERALKEY dev-comment"
+    git config --global commit.gpgsign true
+
+    run bash "$SCRIPT" --force
+    [ "$status" -eq 0 ]
+
+    # The whole point of #116: the [gpg "ssh"] allowedSignersFile block is present.
+    grep -qF 'allowedSignersFile = ' "$SANDBOX/.gitconfig.local"
+    grep -qF '[gpg "ssh"]' "$SANDBOX/.gitconfig.local"
+    # And the signing identity was registered for local verification.
+    [ -f "$SANDBOX/.ssh/allowed_signers" ]
+    grep -qF 'dev@example.com namespaces="git" ssh-ed25519 AAAALITERALKEY' "$SANDBOX/.ssh/allowed_signers"
+}
+
+@test "writes allowedSignersFile when a file-based signing key is configured (no 1Password)" {
+    mkdir -p "$SANDBOX/.ssh"
+    local keyfile="$SANDBOX/.ssh/id_ed25519_signing"
+    echo "ssh-ed25519 AAAAFILEKEY host-comment" > "$keyfile.pub"
+    git config --global user.email "dev@example.com"
+    git config --global user.signingkey "$keyfile"
+    git config --global commit.gpgsign true
+
+    run bash "$SCRIPT" --force
+    [ "$status" -eq 0 ]
+
+    grep -qF 'allowedSignersFile = ' "$SANDBOX/.gitconfig.local"
+    grep -qF 'dev@example.com namespaces="git" ssh-ed25519 AAAAFILEKEY' "$SANDBOX/.ssh/allowed_signers"
+}
+
+@test "skips signing config when no key is configured and 1Password is absent" {
+    git config --global user.email "dev@example.com"   # email only, no signingkey
+
+    run bash "$SCRIPT" --force
+    [ "$status" -eq 0 ]
+
+    # No active signing block, no allowed_signers file — unchanged prior behavior.
+    ! grep -qF 'allowedSignersFile = ' "$SANDBOX/.gitconfig.local"
+    [ ! -f "$SANDBOX/.ssh/allowed_signers" ]
+    # The commented "how to enable" hint is still shown.
+    grep -qF '# Uncomment and set program path' "$SANDBOX/.gitconfig.local"
+}
+
+@test "always includes the core excludesfile and safe directory regardless of signing" {
+    run bash "$SCRIPT" --force
+    [ "$status" -eq 0 ]
+    grep -qF 'excludesfile = ' "$SANDBOX/.gitconfig.local"
+    grep -qF '[safe]' "$SANDBOX/.gitconfig.local"
+}


### PR DESCRIPTION
Fixes #116

## What changed
`scripts/mac version/initialize-local-config.sh` only wrote the `[gpg "ssh"] allowedSignersFile` block when 1Password's `op-ssh-sign` helper was detected. But the shipped `.gitconfig.template` sets a literal `user.signingkey` with `commit.gpgsign = true`, so on a macOS machine **without** 1Password, commits were signed yet `allowedSignersFile` was never written — and `git log --show-signature` / `git verify-commit` reported **"No signature"** for valid signatures.

The fix mirrors the Linux script's behavior: whenever signing is enabled, `allowedSignersFile` is written.

- **1Password present** → unchanged (full block: `program` + `allowedSignersFile` + `gpgsign`).
- **1Password absent but a `user.signingkey` is configured** (literal key or a file-based key path) → now writes a `[gpg "ssh"] allowedSignersFile` block (omitting the nonexistent 1Password `program` line) and registers the identity via the shared `update_allowed_signers` helper, which already resolves both literal keys and `*.pub` files.
- **No key and no 1Password** → still skips, exactly as before (commented "how to enable" hint retained).

## Testing / self-review
- New `tests/shared/mac-initialize-local-config.bats` runs the **real** script in a `HOME`/git-config sandbox and covers all three branches plus the unconditional `[core]`/`[safe]` sections → **4 passed**.
- Full shared suite: **22 bats + 20 pytest pass**.
- `bash -n` clean on the patched script.
- Manual end-to-end run confirmed: with a literal key and no 1Password, `~/.gitconfig.local` gets the `allowedSignersFile` block and `~/.ssh/allowed_signers` gets the identity; with no key, both are correctly absent.
- `git log --show-signature` "No signature" on this Linux box reflects this very class of missing-`allowedSignersFile` setup — the commits in this PR are SSH-signed (verified `gpgsig` header present).