### PR TITLE
2026 review: gitconfig fixes

### DIFF
--- a/.gitconfig.template
+++ b/.gitconfig.template
@@ -15,70 +15,70 @@
 	gpgsign = true
 
 [push]
-    autoSetupRemote = true
+	autoSetupRemote = true
 
 [alias]
-    # Browse all aliases: an interactive, categorized, searchable table when run
-    # in a terminal; pass --plain for a static grouped list (for piping/scripts).
-    alias = !"f() { for p in py python3 python; do command -v \"$p\" >/dev/null 2>&1 && \"$p\" -c '' >/dev/null 2>&1 && exec \"$p\" {{REPO_PATH}}/gitconfig_helper.py print_aliases \"$@\"; done; echo 'No working Python found (tried py, python3, python)' >&2; return 1; }; f"
-    # Download all remote branches creating local counterparts
-    branches = "!git fetch && git for-each-ref --format='%(refname:short)' refs/remotes/origin/ | grep -v -e '^origin/HEAD$' -e '^origin$' | while read ref; do git branch --track \"${ref#origin/}\" \"$ref\" 2>/dev/null || true; done"
-    cleanup = !"f() { for p in py python3 python; do command -v \"$p\" >/dev/null 2>&1 && \"$p\" -c '' >/dev/null 2>&1 && exec \"$p\" {{REPO_PATH}}/gitconfig_helper.py cleanup \"$@\"; done; echo 'No working Python found (tried py, python3, python)' >&2; return 1; }; f"
-    # Switch to main with error handling: fetch, check for uncommitted changes,
-    # checkout main, and pull. Detects and reports merge conflicts.
-    # Pass --all (or -a) to run this for every git repo in immediate subdirectories.
-    main = !"f() { for p in py python3 python; do command -v \"$p\" >/dev/null 2>&1 && \"$p\" -c '' >/dev/null 2>&1 && exec \"$p\" {{REPO_PATH}}/gitconfig_helper.py switch_to_main \"$@\"; done; echo 'No working Python found (tried py, python3, python)' >&2; return 1; }; f"
-    # Manage machine-specific git configuration
-    localconfig = !git config --file ~/.gitconfig.local
-    # Sync the claude-skills repo (~/.claude/skills) on demand, mirroring the
-    # auto-sync's --ff-only safety. Read-only; runs from any directory.
-    skill-sync = !git -C ~/.claude/skills pull --ff-only
-    # Publish new/edited skills in the claude-skills repo (~/.claude/skills) via a
-    # PR (its main is branch-protected): branches off main, prompts for a commit
-    # message, makes a signed commit, opens a PR, and enables squash auto-merge.
-    # Dispatches by OS like selfupdate; runs from any directory.
-    skill-publish = "!f() { case \"$(uname -s)\" in MINGW*|MSYS*|CYGWIN*) powershell -NoProfile -ExecutionPolicy Bypass -File \"$USERPROFILE\\.claude\\skills\\scripts\\publish-skill.ps1\" ;; *) bash \"$HOME/.claude/skills/scripts/publish-skill.sh\" ;; esac; }; f"
-    # Pull the latest gitconfig repo and reinstall ~/.gitconfig from the template
-    # on demand. Dispatches by OS: Git-for-Windows reports MINGW/MSYS/CYGWIN.
-    selfupdate = "!f() { case \"$(uname -s)\" in MINGW*|MSYS*|CYGWIN*) powershell -NoProfile -File '{{REPO_PATH}}/scripts/windows version/Update-GitConfig.ps1' -RepoPath '{{REPO_PATH}}' ;; *) bash '{{REPO_PATH}}/scripts/shared/update-gitconfig.sh' '{{REPO_PATH}}' ;; esac; }; f"
+	# Browse all aliases: an interactive, categorized, searchable table when run
+	# in a terminal; pass --plain for a static grouped list (for piping/scripts).
+	alias = !"f() { for p in py python3 python; do command -v \"$p\" >/dev/null 2>&1 && \"$p\" -c '' >/dev/null 2>&1 && exec \"$p\" {{REPO_PATH}}/gitconfig_helper.py print_aliases \"$@\"; done; echo 'No working Python found (tried py, python3, python)' >&2; return 1; }; f"
+	# Download all remote branches creating local counterparts
+	branches = "!git fetch && git for-each-ref --format='%(refname:short)' refs/remotes/origin/ | grep -v -e '^origin/HEAD$' -e '^origin$' | while read ref; do git branch --track \"${ref#origin/}\" \"$ref\" 2>/dev/null || true; done"
+	cleanup = !"f() { for p in py python3 python; do command -v \"$p\" >/dev/null 2>&1 && \"$p\" -c '' >/dev/null 2>&1 && exec \"$p\" {{REPO_PATH}}/gitconfig_helper.py cleanup \"$@\"; done; echo 'No working Python found (tried py, python3, python)' >&2; return 1; }; f"
+	# Switch to main with error handling: fetch, check for uncommitted changes,
+	# checkout main, and pull. Detects and reports merge conflicts.
+	# Pass --all (or -a) to run this for every git repo in immediate subdirectories.
+	main = !"f() { for p in py python3 python; do command -v \"$p\" >/dev/null 2>&1 && \"$p\" -c '' >/dev/null 2>&1 && exec \"$p\" {{REPO_PATH}}/gitconfig_helper.py switch_to_main \"$@\"; done; echo 'No working Python found (tried py, python3, python)' >&2; return 1; }; f"
+	# Manage machine-specific git configuration
+	localconfig = !git config --file ~/.gitconfig.local
+	# Sync the claude-skills repo (~/.claude/skills) on demand, mirroring the
+	# auto-sync's --ff-only safety. Read-only; runs from any directory.
+	skill-sync = !git -C ~/.claude/skills pull --ff-only
+	# Publish new/edited skills in the claude-skills repo (~/.claude/skills) via a
+	# PR (its main is branch-protected): branches off main, prompts for a commit
+	# message, makes a signed commit, opens a PR, and enables squash auto-merge.
+	# Dispatches by OS like selfupdate; runs from any directory.
+	skill-publish = "!f() { case \"$(uname -s)\" in MINGW*|MSYS*|CYGWIN*) powershell -NoProfile -ExecutionPolicy Bypass -File \"$USERPROFILE\\.claude\\skills\\scripts\\publish-skill.ps1\" ;; *) bash \"$HOME/.claude/skills/scripts/publish-skill.sh\" ;; esac; }; f"
+	# Pull the latest gitconfig repo and reinstall ~/.gitconfig from the template
+	# on demand. Dispatches by OS: Git-for-Windows reports MINGW/MSYS/CYGWIN.
+	selfupdate = "!f() { case \"$(uname -s)\" in MINGW*|MSYS*|CYGWIN*) powershell -NoProfile -File '{{REPO_PATH}}/scripts/windows version/Update-GitConfig.ps1' -RepoPath '{{REPO_PATH}}' ;; *) bash '{{REPO_PATH}}/scripts/shared/update-gitconfig.sh' '{{REPO_PATH}}' ;; esac; }; f"
 
-    # --- Inspect ---
-    # Short, branch-aware working-tree status
-    s = status -sb
-    # Pretty, decorated commit graph across all branches
-    lg = log --graph --oneline --decorate --all
-    # Show the most recent commit with its diffstat
-    last = log -1 HEAD --stat
-    # List local branches ordered by most recent commit
-    recent = for-each-ref --sort=-committerdate --count=15 --format='%(refname:short)' refs/heads/
-    # Find commits that added or removed a string: git find <string>
-    find = log -S
-    # --- Commit ---
-    # Fold staged changes into the last commit, keeping its message
-    amend = commit --amend --no-edit
-    # Edit the last commit's message (opens the editor)
-    reword = commit --amend
-    # Undo the last commit but keep its changes staged
-    undo = reset --soft HEAD~1
-    # Unstage files while keeping working-tree changes
-    unstage = reset HEAD --
-    # Park all current work as a WIP commit (skips hooks)
-    wip = !git add -A && git commit -m 'WIP' --no-verify
-    # --- Branch & Sync ---
-    # Create and switch to a new branch: git nb <name>
-    nb = switch -c
-    # Force-push the current branch safely (refuses to clobber others' work)
-    pushf = push --force-with-lease
-    # Update the current branch with rebase, stashing/restoring local changes
-    sync = pull --rebase --autostash
-    # Start work on a GitHub issue: create a conventionally named branch from its
-    # title (git start <issue-number>). Dispatches to the Python helper.
-    start = !"f() { for p in py python3 python; do command -v \"$p\" >/dev/null 2>&1 && \"$p\" -c '' >/dev/null 2>&1 && exec \"$p\" {{REPO_PATH}}/gitconfig_helper.py start \"$@\"; done; echo 'No working Python found (tried py, python3, python)' >&2; return 1; }; f"
-    # --- GitHub ---
-    # Open the current branch's pull request in the browser
-    pr = !gh pr view --web
-    # Show the status of your pull requests
-    prs = !gh pr status
+	# --- Inspect ---
+	# Short, branch-aware working-tree status
+	s = status -sb
+	# Pretty, decorated commit graph across all branches
+	lg = log --graph --oneline --decorate --all
+	# Show the most recent commit with its diffstat
+	last = log -1 HEAD --stat
+	# List local branches ordered by most recent commit
+	recent = for-each-ref --sort=-committerdate --count=15 --format='%(refname:short)' refs/heads/
+	# Find commits that added or removed a string: git find <string>
+	find = log -S
+	# --- Commit ---
+	# Fold staged changes into the last commit, keeping its message
+	amend = commit --amend --no-edit
+	# Edit the last commit's message (opens the editor)
+	reword = commit --amend
+	# Undo the last commit but keep its changes staged
+	undo = reset --soft HEAD~1
+	# Unstage files while keeping working-tree changes
+	unstage = reset HEAD --
+	# Park all current work as a WIP commit (skips hooks)
+	wip = !git add -A && git commit -m 'WIP' --no-verify
+	# --- Branch & Sync ---
+	# Create and switch to a new branch: git nb <name>
+	nb = switch -c
+	# Force-push the current branch safely (refuses to clobber others' work)
+	pushf = push --force-with-lease
+	# Update the current branch with rebase, stashing/restoring local changes
+	sync = pull --rebase --autostash
+	# Start work on a GitHub issue: create a conventionally named branch from its
+	# title (git start <issue-number>). Dispatches to the Python helper.
+	start = !"f() { for p in py python3 python; do command -v \"$p\" >/dev/null 2>&1 && \"$p\" -c '' >/dev/null 2>&1 && exec \"$p\" {{REPO_PATH}}/gitconfig_helper.py start \"$@\"; done; echo 'No working Python found (tried py, python3, python)' >&2; return 1; }; f"
+	# --- GitHub ---
+	# Open the current branch's pull request in the browser
+	pr = !gh pr view --web
+	# Show the status of your pull requests
+	prs = !gh pr status
 
 [init]
 	defaultBranch = main

--- a/.gitconfig.template
+++ b/.gitconfig.template
@@ -2,10 +2,6 @@
 # This file is used to generate ~/.gitconfig during setup
 # Placeholders: {{REPO_PATH}}, {{HOME_DIR}}
 
-# Include machine-specific configuration (local paths, safe directories, etc.)
-[include]
-	path = ~/.gitconfig.local
-
 # User identification - Customize for your own use
 [user]
 	name = Joey Maffiola
@@ -89,3 +85,10 @@
 
 [core]
 	editor = code --wait
+
+# Include machine-specific configuration (local paths, safe directories, etc.).
+# Kept LAST so values in ~/.gitconfig.local override the template's defaults
+# above (e.g. a file-based signingkey): git applies includes inline and the
+# last declaration of a key wins.
+[include]
+	path = ~/.gitconfig.local

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `scripts/shared/update-gitconfig.sh` — fixed every log line being written **twice**.
+  `log_message` piped through `tee -a "$LOG_FILE"` while the entire main block was already
+  redirected with `>> "$LOG_FILE" 2>&1`, so each line landed in the log once via `tee` and
+  again via the block redirect. The script runs headless under launchd/cron (no terminal),
+  so `log_message` now uses a plain `echo` and the block redirect is the single source of
+  truth ([#114](https://github.com/J-MaFf/gitconfig/issues/114))
+
 - `.gitconfig.template` — normalized indentation to tabs throughout. The `[push]` and
   `[alias]` sections used four-space indentation while every other section used tabs; git
   accepts both but the inconsistency is fragile for any future formatter/validator. All

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `scripts/mac version/initialize-local-config.sh` — always write `[gpg "ssh"]
+  allowedSignersFile` when commit signing is enabled, not only when 1Password's
+  `op-ssh-sign` is detected. The template ships a literal `signingkey` with
+  `commit.gpgsign = true`, so on a macOS box without 1Password the script wrote no
+  `allowedSignersFile` and `git log --show-signature` reported "No signature" for
+  perfectly valid signatures. It now mirrors the Linux script: when `op-ssh-sign` is
+  absent but a `user.signingkey` is configured (literal key or a file-based key), it
+  writes the `allowedSignersFile` block and registers the identity via
+  `update_allowed_signers`. With no key and no 1Password it still skips, as before
+  ([#116](https://github.com/J-MaFf/gitconfig/issues/116))
+
 - `scripts/shared/update-gitconfig.sh` — fixed every log line being written **twice**.
   `log_message` piped through `tee -a "$LOG_FILE"` while the entire main block was already
   redirected with `>> "$LOG_FILE" 2>&1`, so each line landed in the log once via `tee` and

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `.gitconfig.template` — normalized indentation to tabs throughout. The `[push]` and
+  `[alias]` sections used four-space indentation while every other section used tabs; git
+  accepts both but the inconsistency is fragile for any future formatter/validator. All
+  value/comment lines are now tab-indented ([#113](https://github.com/J-MaFf/gitconfig/issues/113))
+
 - `.gitconfig.template` — moved the `[include] path = ~/.gitconfig.local` directive to the
   **bottom** of the template. Git applies includes inline and the last declaration of a key
   wins, so with the include at the top the template's hardcoded literal `signingkey` silently

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -30,6 +30,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Cross-platform test coverage for the shared scripts. Until now every test was Pester
+  (Windows-only), leaving `scripts/shared/functions.sh` and `gitconfig_helper.py` untested
+  on the primary dev platforms. Added `tests/shared/functions.bats` (bats-core) covering
+  `backup_file`, `create_symlink`, `update_allowed_signers`, `generate_gitconfig`, and the
+  git-alias widget enable/disable, plus `tests/shared/test_gitconfig_helper.py` (pytest)
+  covering `_slugify`, `LABEL_PREFIX` selection, `_have`, `_default_branch`, and
+  `get_git_aliases` parsing. See `tests/shared/README.md` to run them
+  ([#115](https://github.com/J-MaFf/gitconfig/issues/115))
+
 - `git alias` browser — when the interactive browser can't launch it no longer falls back
   to the static table **silently**: it prints a one-line reason to stderr (only when stderr
   is a TTY, so pipes/CI stay clean) — e.g. `textual` not installed, stdout not a TTY, or a

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- `.gitconfig.template` — moved the `[include] path = ~/.gitconfig.local` directive to the
+  **bottom** of the template. Git applies includes inline and the last declaration of a key
+  wins, so with the include at the top the template's hardcoded literal `signingkey` silently
+  overrode whatever the local config set (e.g. the file-based key on Linux). The include now
+  runs last, so `~/.gitconfig.local` overrides take effect
+  ([#112](https://github.com/J-MaFf/gitconfig/issues/112))
+
 ### Added
 
 - `git alias` browser — when the interactive browser can't launch it no longer falls back

--- a/scripts/mac version/initialize-local-config.sh
+++ b/scripts/mac version/initialize-local-config.sh
@@ -77,6 +77,14 @@ CONFIG_CONTENT="# Machine-Specific Git Configuration (macOS)
 	excludesfile = $HOME_DIR/.gitignore_global
 "
 
+# A signing key may already be configured in git even without 1Password — e.g.
+# the template ships a literal signingkey with commit.gpgsign=true, or a user
+# points user.signingkey at a file-based key. In all of those cases signing is
+# active, so allowedSignersFile must be written or git reports "No signature"
+# on verification. Mirror the Linux behavior: whenever signing is enabled, write
+# the [gpg "ssh"] allowedSignersFile block.
+EXISTING_SIGNING_KEY="$(git config --get user.signingkey 2>/dev/null || true)"
+
 SIGNING_ENABLED=false
 if [ -n "$OP_SSH_SIGN" ]; then
     echo "[INFO] Detected 1Password SSH signing helper: $OP_SSH_SIGN"
@@ -93,8 +101,24 @@ if [ -n "$OP_SSH_SIGN" ]; then
 [commit]
 	gpgsign = true
 "
+elif [ -n "$EXISTING_SIGNING_KEY" ]; then
+    # op-ssh-sign isn't installed, but a signing key is already configured
+    # (file-based key or a literal public key). Still write allowedSignersFile
+    # so signatures verify locally; omit the 1Password program line.
+    echo "[INFO] op-ssh-sign not found, but a signing key is configured:"
+    echo "       $EXISTING_SIGNING_KEY"
+    echo "       Writing allowedSignersFile so signatures verify locally."
+    SIGNING_ENABLED=true
+    CONFIG_CONTENT+="
+[gpg]
+	format = ssh
+
+[gpg \"ssh\"]
+	# Lets git verify SSH commit signatures locally (git log --show-signature)
+	allowedSignersFile = $HOME_DIR/.ssh/allowed_signers
+"
 else
-    echo "[INFO] op-ssh-sign not found — skipping SSH signing config."
+    echo "[INFO] op-ssh-sign not found and no signing key configured — skipping signing config."
     echo "       Install 1Password CLI via Homebrew to enable commit signing:"
     echo "         brew install 1password-cli"
     CONFIG_CONTENT+="

--- a/scripts/shared/update-gitconfig.sh
+++ b/scripts/shared/update-gitconfig.sh
@@ -10,7 +10,12 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 log_message() {
     local timestamp
     timestamp=$(date '+%Y-%m-%d %H:%M:%S')
-    echo "[$timestamp] $1" | tee -a "$LOG_FILE"
+    # The whole main block below is redirected to "$LOG_FILE", so a plain echo
+    # already reaches the log. Using `tee -a "$LOG_FILE"` here would write the
+    # line a second time (once via tee, once via the block redirect). This runs
+    # headless under launchd/cron with no terminal attached, so the block
+    # redirect is the single source of truth for log output.
+    echo "[$timestamp] $1"
 }
 
 mkdir -p "$(dirname "$LOG_FILE")"

--- a/tests/shared/README.md
+++ b/tests/shared/README.md
@@ -1,0 +1,36 @@
+# Shared-script tests (Linux / macOS)
+
+These suites cover the cross-platform bash and Python code that the mac and
+linux setup scripts depend on. They complement the Windows-only Pester suite in
+`../` so regressions on the primary dev platforms are caught.
+
+| Suite | Runner | Covers |
+| --- | --- | --- |
+| `functions.bats` | [bats-core](https://github.com/bats-core/bats-core) | `scripts/shared/functions.sh` — `backup_file`, `create_symlink`, `update_allowed_signers`, `generate_gitconfig`, git-alias widget enable/disable |
+| `test_gitconfig_helper.py` | [pytest](https://docs.pytest.org/) | `gitconfig_helper.py` — `_slugify`, `LABEL_PREFIX` selection, `_have`, `_default_branch`, `get_git_aliases` |
+
+## Running
+
+### Bash (bats)
+
+```sh
+# Install bats-core (one of):
+#   brew install bats-core            # macOS
+#   sudo apt-get install bats         # Debian/Ubuntu
+#   git clone https://github.com/bats-core/bats-core && ./bats-core/install.sh ~/.local
+bats tests/shared/functions.bats
+```
+
+The suite redirects `GIT_CONFIG_GLOBAL` / `GIT_CONFIG_SYSTEM` and works inside a
+`mktemp -d` sandbox, so it never touches your real `~/.gitconfig`,
+`~/.gitconfig.local`, `~/.ssh/allowed_signers`, or shell rc files.
+
+### Python (pytest)
+
+```sh
+python -m pip install pytest rich   # rich is gitconfig_helper.py's own dependency
+pytest tests/shared/test_gitconfig_helper.py
+```
+
+The pytest suite imports `gitconfig_helper.py` by path and monkeypatches
+`run_git`, so it needs neither a real repository nor network access.

--- a/tests/shared/README.md
+++ b/tests/shared/README.md
@@ -7,6 +7,7 @@ linux setup scripts depend on. They complement the Windows-only Pester suite in
 | Suite | Runner | Covers |
 | --- | --- | --- |
 | `functions.bats` | [bats-core](https://github.com/bats-core/bats-core) | `scripts/shared/functions.sh` — `backup_file`, `create_symlink`, `update_allowed_signers`, `generate_gitconfig`, git-alias widget enable/disable |
+| `mac-initialize-local-config.bats` | bats-core | `scripts/mac version/initialize-local-config.sh` — always writes `allowedSignersFile` when signing is enabled ([#116](https://github.com/J-MaFf/gitconfig/issues/116)) |
 | `test_gitconfig_helper.py` | [pytest](https://docs.pytest.org/) | `gitconfig_helper.py` — `_slugify`, `LABEL_PREFIX` selection, `_have`, `_default_branch`, `get_git_aliases` |
 
 ## Running
@@ -18,7 +19,7 @@ linux setup scripts depend on. They complement the Windows-only Pester suite in
 #   brew install bats-core            # macOS
 #   sudo apt-get install bats         # Debian/Ubuntu
 #   git clone https://github.com/bats-core/bats-core && ./bats-core/install.sh ~/.local
-bats tests/shared/functions.bats
+bats tests/shared/        # runs every *.bats in this directory
 ```
 
 The suite redirects `GIT_CONFIG_GLOBAL` / `GIT_CONFIG_SYSTEM` and works inside a

--- a/tests/shared/functions.bats
+++ b/tests/shared/functions.bats
@@ -1,0 +1,224 @@
+#!/usr/bin/env bats
+#
+# Bats suite for scripts/shared/functions.sh — the bash utilities sourced by
+# the mac and linux gitconfig scripts. Complements the Windows-only Pester
+# suite so regressions on the primary dev platforms are caught.
+#
+# Run with:  bats tests/shared/functions.bats
+# Requires:  bats-core (https://github.com/bats-core/bats-core) and git.
+
+setup() {
+    REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)"
+    # shellcheck source=../../scripts/shared/functions.sh
+    source "$REPO_ROOT/scripts/shared/functions.sh"
+
+    TESTDIR="$(mktemp -d)"
+    HOME_DIR="$TESTDIR/home"
+    mkdir -p "$HOME_DIR"
+
+    # Isolate git config so update_allowed_signers reads only what we seed and
+    # never touches the developer's real ~/.gitconfig.
+    export GIT_CONFIG_GLOBAL="$TESTDIR/gitconfig-global"
+    export GIT_CONFIG_SYSTEM="$TESTDIR/no-system-config"
+    : > "$GIT_CONFIG_GLOBAL"
+}
+
+teardown() {
+    rm -rf "$TESTDIR"
+}
+
+# ---------------------------------------------------------------------------
+# backup_file
+# ---------------------------------------------------------------------------
+
+@test "backup_file moves an existing file to Existing.<name>.bak" {
+    echo "original" > "$TESTDIR/.gitconfig"
+    run backup_file "$TESTDIR/.gitconfig"
+    [ "$status" -eq 0 ]
+    [ ! -e "$TESTDIR/.gitconfig" ]
+    [ -f "$TESTDIR/Existing..gitconfig.bak" ]
+    [ "$(cat "$TESTDIR/Existing..gitconfig.bak")" = "original" ]
+}
+
+@test "backup_file returns 1 and skips when the target is missing" {
+    run backup_file "$TESTDIR/does-not-exist"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"[SKIP]"* ]]
+}
+
+@test "backup_file overwrites a stale backup instead of failing" {
+    echo "stale" > "$TESTDIR/Existing.file.bak"
+    echo "fresh" > "$TESTDIR/file"
+    run backup_file "$TESTDIR/file"
+    [ "$status" -eq 0 ]
+    [ "$(cat "$TESTDIR/Existing.file.bak")" = "fresh" ]
+}
+
+# ---------------------------------------------------------------------------
+# create_symlink
+# ---------------------------------------------------------------------------
+
+@test "create_symlink links source to destination" {
+    echo "src" > "$TESTDIR/source"
+    run create_symlink "$TESTDIR/source" "$TESTDIR/link" true
+    [ "$status" -eq 0 ]
+    [ -L "$TESTDIR/link" ]
+    [ "$(cat "$TESTDIR/link")" = "src" ]
+}
+
+@test "create_symlink errors when the source is missing" {
+    run create_symlink "$TESTDIR/missing" "$TESTDIR/link" true
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"[ERROR]"* ]]
+    [ ! -e "$TESTDIR/link" ]
+}
+
+@test "create_symlink backs up an existing destination with force=true" {
+    echo "src" > "$TESTDIR/source"
+    echo "old" > "$TESTDIR/link"
+    run create_symlink "$TESTDIR/source" "$TESTDIR/link" true
+    [ "$status" -eq 0 ]
+    [ -L "$TESTDIR/link" ]
+    [ -f "$TESTDIR/Existing.link.bak" ]
+    [ "$(cat "$TESTDIR/Existing.link.bak")" = "old" ]
+}
+
+# ---------------------------------------------------------------------------
+# update_allowed_signers  (the helper behind issue #116)
+# ---------------------------------------------------------------------------
+
+@test "update_allowed_signers writes the signing identity for a literal key" {
+    git config --global user.email "dev@example.com"
+    git config --global user.signingkey "ssh-ed25519 AAAATESTKEY a-comment"
+    local signers="$HOME_DIR/.ssh/allowed_signers"
+
+    run update_allowed_signers "$signers"
+    [ "$status" -eq 0 ]
+    [ -f "$signers" ]
+    # Email + git namespace + normalized "<type> <base64>" (comment dropped).
+    grep -qF 'dev@example.com namespaces="git" ssh-ed25519 AAAATESTKEY' "$signers"
+    ! grep -q 'a-comment' "$signers"
+}
+
+@test "update_allowed_signers is idempotent (no duplicate lines)" {
+    git config --global user.email "dev@example.com"
+    git config --global user.signingkey "ssh-ed25519 AAAATESTKEY a-comment"
+    local signers="$HOME_DIR/.ssh/allowed_signers"
+
+    update_allowed_signers "$signers"
+    update_allowed_signers "$signers"
+    [ "$(grep -c 'dev@example.com' "$signers")" -eq 1 ]
+}
+
+@test "update_allowed_signers resolves a file-based key from its .pub file" {
+    local keyfile="$HOME_DIR/.ssh/id_ed25519_signing"
+    mkdir -p "$HOME_DIR/.ssh"
+    echo "ssh-ed25519 AAAAFILEKEY host-comment" > "$keyfile.pub"
+    git config --global user.email "dev@example.com"
+    git config --global user.signingkey "$keyfile"
+    local signers="$HOME_DIR/.ssh/allowed_signers"
+
+    run update_allowed_signers "$signers"
+    [ "$status" -eq 0 ]
+    grep -qF 'dev@example.com namespaces="git" ssh-ed25519 AAAAFILEKEY' "$signers"
+}
+
+@test "update_allowed_signers skips gracefully when no signing key is set" {
+    git config --global user.email "dev@example.com"
+    local signers="$HOME_DIR/.ssh/allowed_signers"
+
+    run update_allowed_signers "$signers"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"[WARN]"* ]]
+    [ ! -f "$signers" ]
+}
+
+@test "update_allowed_signers preserves other identities already present" {
+    mkdir -p "$HOME_DIR/.ssh"
+    local signers="$HOME_DIR/.ssh/allowed_signers"
+    echo 'other@example.com namespaces="git" ssh-ed25519 AAAAOTHER' > "$signers"
+    git config --global user.email "dev@example.com"
+    git config --global user.signingkey "ssh-ed25519 AAAATESTKEY a-comment"
+
+    run update_allowed_signers "$signers"
+    [ "$status" -eq 0 ]
+    grep -qF 'other@example.com' "$signers"
+    grep -qF 'dev@example.com' "$signers"
+}
+
+# ---------------------------------------------------------------------------
+# generate_gitconfig
+# ---------------------------------------------------------------------------
+
+@test "generate_gitconfig substitutes placeholders and writes output" {
+    local repo="$TESTDIR/repo"
+    mkdir -p "$repo"
+    printf '[core]\n\trepo = {{REPO_PATH}}\n\thome = {{HOME_DIR}}\n' > "$repo/.gitconfig.template"
+
+    run generate_gitconfig "$repo" "$HOME_DIR" true
+    [ "$status" -eq 0 ]
+    [ -f "$HOME_DIR/.gitconfig" ]
+    grep -qF "repo = $repo" "$HOME_DIR/.gitconfig"
+    grep -qF "home = $HOME_DIR" "$HOME_DIR/.gitconfig"
+    ! grep -q '{{' "$HOME_DIR/.gitconfig"
+}
+
+@test "generate_gitconfig errors when the template is missing" {
+    local repo="$TESTDIR/repo-no-template"
+    mkdir -p "$repo"
+    run generate_gitconfig "$repo" "$HOME_DIR" true
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"[ERROR]"* ]]
+}
+
+@test "generate_gitconfig backs up an existing config when forced" {
+    local repo="$TESTDIR/repo"
+    mkdir -p "$repo"
+    printf '[core]\n\trepo = {{REPO_PATH}}\n' > "$repo/.gitconfig.template"
+    echo "prior" > "$HOME_DIR/.gitconfig"
+
+    run generate_gitconfig "$repo" "$HOME_DIR" true
+    [ "$status" -eq 0 ]
+    [ -f "$HOME_DIR/.gitconfig.bak" ]
+    [ "$(cat "$HOME_DIR/.gitconfig.bak")" = "prior" ]
+}
+
+# ---------------------------------------------------------------------------
+# enable_git_alias_widget / disable_git_alias_widget
+# ---------------------------------------------------------------------------
+
+@test "enable_git_alias_widget adds a guarded marker block to an existing rc" {
+    : > "$HOME_DIR/.bashrc"
+    : > "$HOME_DIR/.zshrc"
+    run enable_git_alias_widget "$REPO_ROOT" "$HOME_DIR"
+    [ "$status" -eq 0 ]
+    grep -qF "$GIT_ALIAS_WIDGET_BEGIN" "$HOME_DIR/.bashrc"
+    grep -qF "$GIT_ALIAS_WIDGET_END" "$HOME_DIR/.bashrc"
+    grep -qF "git-alias-widget.bash" "$HOME_DIR/.bashrc"
+}
+
+@test "enable_git_alias_widget is idempotent (single marker block)" {
+    : > "$HOME_DIR/.bashrc"
+    enable_git_alias_widget "$REPO_ROOT" "$HOME_DIR"
+    enable_git_alias_widget "$REPO_ROOT" "$HOME_DIR"
+    [ "$(grep -cF "$GIT_ALIAS_WIDGET_BEGIN" "$HOME_DIR/.bashrc")" -eq 1 ]
+}
+
+@test "disable_git_alias_widget removes the marker block it added" {
+    : > "$HOME_DIR/.bashrc"
+    enable_git_alias_widget "$REPO_ROOT" "$HOME_DIR"
+    run disable_git_alias_widget "$HOME_DIR"
+    [ "$status" -eq 0 ]
+    ! grep -qF "$GIT_ALIAS_WIDGET_BEGIN" "$HOME_DIR/.bashrc"
+    ! grep -qF "$GIT_ALIAS_WIDGET_END" "$HOME_DIR/.bashrc"
+}
+
+@test "disable_git_alias_widget preserves surrounding rc content" {
+    printf 'export FOO=1\n' > "$HOME_DIR/.bashrc"
+    enable_git_alias_widget "$REPO_ROOT" "$HOME_DIR"
+    printf 'export BAR=2\n' >> "$HOME_DIR/.bashrc"
+    disable_git_alias_widget "$HOME_DIR"
+    grep -qF 'export FOO=1' "$HOME_DIR/.bashrc"
+    grep -qF 'export BAR=2' "$HOME_DIR/.bashrc"
+    ! grep -qF "$GIT_ALIAS_WIDGET_BEGIN" "$HOME_DIR/.bashrc"
+}

--- a/tests/shared/mac-initialize-local-config.bats
+++ b/tests/shared/mac-initialize-local-config.bats
@@ -1,0 +1,81 @@
+#!/usr/bin/env bats
+#
+# Bats suite for scripts/mac version/initialize-local-config.sh, focused on the
+# allowedSignersFile behavior (issue #116): on macOS, allowedSignersFile must be
+# written whenever signing is enabled — not only when 1Password's op-ssh-sign is
+# installed. Otherwise `git log --show-signature` reports "No signature" for a
+# file-based or literal signing key.
+#
+# These tests run the real script in a mktemp sandbox with HOME and git config
+# redirected, so they never touch the developer's machine. op-ssh-sign is not on
+# the sandbox's fixed lookup paths (/opt/homebrew/bin, /usr/local/bin), so the
+# "no 1Password" branches are exercised naturally.
+#
+# Run with:  bats tests/shared/mac-initialize-local-config.bats
+# Requires:  bats-core and git.
+
+setup() {
+    REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)"
+    SCRIPT="$REPO_ROOT/scripts/mac version/initialize-local-config.sh"
+
+    SANDBOX="$(mktemp -d)"
+    export HOME="$SANDBOX"
+    export GIT_CONFIG_GLOBAL="$SANDBOX/.gitconfig"
+    export GIT_CONFIG_SYSTEM="$SANDBOX/no-system-config"
+    : > "$GIT_CONFIG_GLOBAL"
+}
+
+teardown() {
+    rm -rf "$SANDBOX"
+}
+
+@test "writes allowedSignersFile when a literal signing key is configured (no 1Password)" {
+    git config --global user.email "dev@example.com"
+    git config --global user.signingkey "ssh-ed25519 AAAALITERALKEY dev-comment"
+    git config --global commit.gpgsign true
+
+    run bash "$SCRIPT" --force
+    [ "$status" -eq 0 ]
+
+    # The whole point of #116: the [gpg "ssh"] allowedSignersFile block is present.
+    grep -qF 'allowedSignersFile = ' "$SANDBOX/.gitconfig.local"
+    grep -qF '[gpg "ssh"]' "$SANDBOX/.gitconfig.local"
+    # And the signing identity was registered for local verification.
+    [ -f "$SANDBOX/.ssh/allowed_signers" ]
+    grep -qF 'dev@example.com namespaces="git" ssh-ed25519 AAAALITERALKEY' "$SANDBOX/.ssh/allowed_signers"
+}
+
+@test "writes allowedSignersFile when a file-based signing key is configured (no 1Password)" {
+    mkdir -p "$SANDBOX/.ssh"
+    local keyfile="$SANDBOX/.ssh/id_ed25519_signing"
+    echo "ssh-ed25519 AAAAFILEKEY host-comment" > "$keyfile.pub"
+    git config --global user.email "dev@example.com"
+    git config --global user.signingkey "$keyfile"
+    git config --global commit.gpgsign true
+
+    run bash "$SCRIPT" --force
+    [ "$status" -eq 0 ]
+
+    grep -qF 'allowedSignersFile = ' "$SANDBOX/.gitconfig.local"
+    grep -qF 'dev@example.com namespaces="git" ssh-ed25519 AAAAFILEKEY' "$SANDBOX/.ssh/allowed_signers"
+}
+
+@test "skips signing config when no key is configured and 1Password is absent" {
+    git config --global user.email "dev@example.com"   # email only, no signingkey
+
+    run bash "$SCRIPT" --force
+    [ "$status" -eq 0 ]
+
+    # No active signing block, no allowed_signers file — unchanged prior behavior.
+    ! grep -qF 'allowedSignersFile = ' "$SANDBOX/.gitconfig.local"
+    [ ! -f "$SANDBOX/.ssh/allowed_signers" ]
+    # The commented "how to enable" hint is still shown.
+    grep -qF '# Uncomment and set program path' "$SANDBOX/.gitconfig.local"
+}
+
+@test "always includes the core excludesfile and safe directory regardless of signing" {
+    run bash "$SCRIPT" --force
+    [ "$status" -eq 0 ]
+    grep -qF 'excludesfile = ' "$SANDBOX/.gitconfig.local"
+    grep -qF '[safe]' "$SANDBOX/.gitconfig.local"
+}

--- a/tests/shared/test_gitconfig_helper.py
+++ b/tests/shared/test_gitconfig_helper.py
@@ -1,0 +1,203 @@
+# Pytest suite for the pure-logic helpers in gitconfig_helper.py.
+#
+# These run on the primary dev platforms (Linux/macOS), complementing the
+# Windows-only Pester suite. They exercise the deterministic, side-effect-free
+# parts of the helper (slugifying, label->prefix mapping, default-branch
+# resolution, alias parsing) so regressions are caught without needing a real
+# repository or network access.
+#
+# Run with:  pytest tests/shared/test_gitconfig_helper.py
+# Requires:  pytest and the helper's own dependency, `rich`.
+
+import importlib.util
+import os
+import sys
+
+import pytest
+
+REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
+HELPER_PATH = os.path.join(REPO_ROOT, "gitconfig_helper.py")
+
+
+def _load_helper():
+    """Import gitconfig_helper.py by path (it lives at the repo root, not on
+    sys.path, and is not a package)."""
+    spec = importlib.util.spec_from_file_location("gitconfig_helper", HELPER_PATH)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture(scope="module")
+def helper():
+    return _load_helper()
+
+
+# --------------------------------------------------------------------------
+# _slugify
+# --------------------------------------------------------------------------
+
+class TestSlugify:
+    def test_basic_title(self, helper):
+        assert helper._slugify("Add bash test coverage") == "add-bash-test-coverage"
+
+    def test_collapses_punctuation_and_spaces(self, helper):
+        assert helper._slugify("Fix:  the   bug!!!") == "fix-the-bug"
+
+    def test_strips_leading_and_trailing_separators(self, helper):
+        assert helper._slugify("  --Hello, World--  ") == "hello-world"
+
+    def test_lowercases(self, helper):
+        assert helper._slugify("CamelCase TITLE") == "camelcase-title"
+
+    def test_truncates_to_max_length_without_trailing_dash(self, helper):
+        title = "word " * 40  # far longer than the default 50-char cap
+        slug = helper._slugify(title)
+        assert len(slug) <= 50
+        assert not slug.endswith("-")
+
+    def test_custom_max_length(self, helper):
+        slug = helper._slugify("one two three four five", max_length=7)
+        assert len(slug) <= 7
+        assert not slug.endswith("-")
+
+    def test_empty_input_falls_back_to_issue(self, helper):
+        assert helper._slugify("") == "issue"
+
+    def test_punctuation_only_falls_back_to_issue(self, helper):
+        assert helper._slugify("!!!@@@###") == "issue"
+
+
+# --------------------------------------------------------------------------
+# LABEL_PREFIX  (drives the fix/feat/docs branch prefix in start_branch)
+# --------------------------------------------------------------------------
+
+class TestLabelPrefix:
+    def test_known_labels_map_to_expected_prefixes(self, helper):
+        assert helper.LABEL_PREFIX["bug"] == "fix"
+        assert helper.LABEL_PREFIX["enhancement"] == "feat"
+        assert helper.LABEL_PREFIX["feature"] == "feat"
+        assert helper.LABEL_PREFIX["documentation"] == "docs"
+        assert helper.LABEL_PREFIX["docs"] == "docs"
+
+    def test_first_matching_label_wins(self, helper):
+        # Mirrors the selection logic in start_branch: first label that is a
+        # known key determines the prefix, defaulting to "feat".
+        labels = ["wontfix", "bug", "enhancement"]
+        prefix = next(
+            (helper.LABEL_PREFIX[label] for label in labels if label in helper.LABEL_PREFIX),
+            "feat",
+        )
+        assert prefix == "fix"
+
+    def test_unknown_labels_default_to_feat(self, helper):
+        labels = ["question", "triage"]
+        prefix = next(
+            (helper.LABEL_PREFIX[label] for label in labels if label in helper.LABEL_PREFIX),
+            "feat",
+        )
+        assert prefix == "feat"
+
+
+# --------------------------------------------------------------------------
+# _have  (PATH lookup wrapper)
+# --------------------------------------------------------------------------
+
+class TestHave:
+    def test_returns_true_for_present_executable(self, helper):
+        # git is required for the whole project, so it is a safe positive.
+        assert helper._have("git") is True
+
+    def test_returns_false_for_absent_executable(self, helper):
+        assert helper._have("definitely-not-a-real-command-xyz") is False
+
+
+# --------------------------------------------------------------------------
+# _default_branch  (reads git config init.defaultBranch, falls back to main)
+# --------------------------------------------------------------------------
+
+class TestDefaultBranch:
+    def test_falls_back_to_main_when_unset(self, helper, monkeypatch):
+        class _Result:
+            returncode = 1
+            stdout = ""
+
+        monkeypatch.setattr(helper, "run_git", lambda *a, **k: _Result())
+        assert helper._default_branch() == "main"
+
+    def test_uses_configured_value(self, helper, monkeypatch):
+        class _Result:
+            returncode = 0
+            stdout = "trunk\n"
+
+        monkeypatch.setattr(helper, "run_git", lambda *a, **k: _Result())
+        assert helper._default_branch() == "trunk"
+
+
+# --------------------------------------------------------------------------
+# get_git_aliases  (parses `git config --get-regexp alias` output)
+# --------------------------------------------------------------------------
+
+class TestGetGitAliases:
+    def _patch_git_output(self, helper, monkeypatch, stdout, returncode=0):
+        class _Result:
+            pass
+
+        res = _Result()
+        res.returncode = returncode
+        res.stdout = stdout
+
+        def fake_run_git(*args, check=False):
+            if check and returncode != 0:
+                import subprocess
+
+                raise subprocess.CalledProcessError(returncode, args)
+            return res
+
+        monkeypatch.setattr(helper, "run_git", fake_run_git)
+
+    def test_known_alias_uses_curated_metadata(self, helper, monkeypatch):
+        self._patch_git_output(helper, monkeypatch, "alias.s status -sb\n")
+        aliases = helper.get_git_aliases()
+        assert len(aliases) == 1
+        name, description, category = aliases[0]
+        assert name == "s"
+        assert category == "Inspect"
+        # Curated description from ALIAS_METADATA, not the raw value.
+        assert description == helper.ALIAS_METADATA["s"][1]
+
+    def test_unknown_shell_alias_is_categorized_as_other(self, helper, monkeypatch):
+        self._patch_git_output(helper, monkeypatch, "alias.foo !echo hi\n")
+        aliases = helper.get_git_aliases()
+        assert len(aliases) == 1
+        name, description, category = aliases[0]
+        assert name == "foo"
+        assert category == "Other"
+        assert description.startswith("Shell: ")
+
+    def test_unknown_plain_alias_is_categorized_as_other(self, helper, monkeypatch):
+        self._patch_git_output(helper, monkeypatch, "alias.co checkout\n")
+        aliases = helper.get_git_aliases()
+        name, description, category = aliases[0]
+        assert name == "co"
+        assert category == "Other"
+        assert description == "checkout"
+
+    def test_results_sorted_by_category_then_name(self, helper, monkeypatch):
+        # "s" is Inspect (earlier in CATEGORY_ORDER), "zzz" is Other (last).
+        self._patch_git_output(helper, monkeypatch, "alias.zzz !echo z\nalias.s status -sb\n")
+        aliases = helper.get_git_aliases()
+        categories = [a[2] for a in aliases]
+        order = {c: i for i, c in enumerate(helper.CATEGORY_ORDER)}
+        assert [order[c] for c in categories] == sorted(order[c] for c in categories)
+        # Inspect ("s") must come before Other ("zzz").
+        assert aliases[0][0] == "s"
+
+    def test_empty_config_returns_empty_list(self, helper, monkeypatch):
+        # `git config --get-regexp alias` exits non-zero when no aliases exist.
+        self._patch_git_output(helper, monkeypatch, "", returncode=1)
+        assert helper.get_git_aliases() == []
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-v"]))


### PR DESCRIPTION
Aggregated 2026 code-review fixes for manual review. Do not merge until reviewed.

Fixes #112
Fixes #113
Fixes #114
Fixes #115
Fixes #116

## Issues addressed
- **#112** — `.gitconfig.template`: moved `[include] path = ~/.gitconfig.local` to the bottom so machine-local overrides (e.g. a file-based `signingkey`) win over the template's hardcoded defaults (PR #117).
- **#113** — `.gitconfig.template`: normalized mixed tabs/spaces to tabs throughout (the `[push]` and `[alias]` sections used 4-space indent) (PR #118).
- **#114** — `scripts/shared/update-gitconfig.sh`: stopped every log line being written twice (`log_message` piped through `tee -a` while the whole block was already redirected to the log) (PR #119).
- **#115** — added cross-platform test coverage for the shared scripts: `tests/shared/functions.bats` (bats) for `scripts/shared/functions.sh` and `tests/shared/test_gitconfig_helper.py` (pytest) for `gitconfig_helper.py`, since all prior tests were Windows-only Pester (PR #120).
- **#116** — `scripts/mac version/initialize-local-config.sh`: always write `[gpg "ssh"] allowedSignersFile` when signing is enabled (not only when 1Password is present), so `git log --show-signature` no longer reports "No signature" for a file-based or literal key on macOS. Mirrors the Linux behavior (PR #121).

## Testing
- `pytest tests/shared/` → 20 passed
- `bats tests/shared/` → 22 passed (run against vendored bats-core 1.13.0)
- `bash -n` clean on all touched shell scripts
- #116 verified end-to-end in a HOME/git-config sandbox: `allowedSignersFile` + `~/.ssh/allowed_signers` are written when a key is configured without 1Password, and correctly skipped when no key is present.
- Windows-only Pester suite unchanged and not run here (Linux CI).

Each fix landed via its own squash-merged PR (#117-#121) into `2026-review`; this PR aggregates them for a final review pass before merging to `main`.