### PR TITLE
feat: repoint skill-sync alias to the claude-skills wrapper (status -> pull -> status)

### DIFF
--- a/.gitconfig.template
+++ b/.gitconfig.template
@@ -34,9 +34,11 @@
     main = !"f() { for p in py python3 python; do command -v \"$p\" >/dev/null 2>&1 && \"$p\" -c '' >/dev/null 2>&1 && exec \"$p\" {{REPO_PATH}}/gitconfig_helper.py switch_to_main \"$@\"; done; echo 'No working Python found (tried py, python3, python)' >&2; return 1; }; f"
     # Manage machine-specific git configuration
     localconfig = !git config --file ~/.gitconfig.local
-    # Sync the claude-skills repo (~/.claude/skills) on demand, mirroring the
-    # auto-sync's --ff-only safety. Read-only; runs from any directory.
-    skill-sync = !git -C ~/.claude/skills pull --ff-only
+    # Sync the claude-skills repo (~/.claude/skills) on demand: show status, pull
+    # --ff-only, show status again, so unpublished local work is surfaced before and
+    # after. Dispatches by OS like skill-publish; runs from any directory. The wrapper
+    # lives in the claude-skills repo so future tweaks sync without touching this alias.
+    skill-sync = "!f() { case \"$(uname -s)\" in MINGW*|MSYS*|CYGWIN*) powershell -NoProfile -ExecutionPolicy Bypass -File \"$USERPROFILE\\.claude\\skills\\scripts\\skill-sync.ps1\" ;; *) bash \"$HOME/.claude/skills/scripts/skill-sync.sh\" ;; esac; }; f"
     # Publish new/edited skills in the claude-skills repo (~/.claude/skills) via a
     # PR (its main is branch-protected): branches off main, prompts for a commit
     # message, makes a signed commit, opens a PR, and enables squash auto-merge.

--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ git selfupdate           # Pull this repo and reinstall ~/.gitconfig from the te
 **Claude Skills**
 
 ```bash
-git skill-sync           # Sync the claude-skills repo (~/.claude/skills) with pull --ff-only
+git skill-sync           # Sync ~/.claude/skills: status -> pull --ff-only -> status
 git skill-publish        # Publish new/edited skills via a PR (prompts for a message, auto-merges)
 ```
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -67,6 +67,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- `git skill-sync` now dispatches by OS to the claude-skills `skill-sync.{sh,ps1}` wrapper
+  (status → `pull --ff-only` → status) instead of running the bare `pull --ff-only`, so a
+  skill edited on one machine but not yet published is surfaced before and after the sync.
+  Pointing the alias at an auto-syncing script means future changes need no further gitconfig
+  update ([#123](https://github.com/J-MaFf/gitconfig/issues/123))
 - The auto-update job (`git selfupdate` and the login-triggered run) now also
   ensures the optional `textual` dependency is installed — best-effort and only
   when missing — so existing machines pick up the interactive `git alias` browser

--- a/gitconfig_helper.py
+++ b/gitconfig_helper.py
@@ -224,7 +224,7 @@ ALIAS_METADATA = {
     "localconfig": ("Maintenance", "Edit machine-specific git config (~/.gitconfig.local)"),
     "selfupdate": ("Maintenance", "Pull this repo and reinstall ~/.gitconfig from the template"),
     # Claude Skills
-    "skill-sync": ("Claude Skills", "Sync the claude-skills repo (~/.claude/skills): pull --ff-only"),
+    "skill-sync": ("Claude Skills", "Sync ~/.claude/skills: status, pull --ff-only, status (flags unpublished local work)"),
     "skill-publish": ("Claude Skills", "Publish new/edited skills (~/.claude/skills) via a PR with auto-merge"),
 }
 


### PR DESCRIPTION
Fixes #123

`git skill-sync` now dispatches by OS to `~/.claude/skills/scripts/skill-sync.{ps1,sh}` (status → `pull --ff-only` → status), mirroring how `skill-publish` already dispatches, instead of running the bare `git -C ~/.claude/skills pull --ff-only`. This surfaces unpublished local work before and after a manual sync.

Pointing the alias at an auto-syncing script (it lives in the claude-skills repo) means future behavior changes ride the normal skill sync — no further per-machine gitconfig update.

## Changes
- `.gitconfig.template` — `skill-sync` → `uname`-based dispatch to `skill-sync.ps1` / `skill-sync.sh`
- `gitconfig_helper.py` + `README.md` — refresh the alias description (stays in the "Claude Skills" category; ASCII-only)
- `docs/CHANGELOG.md` — entry

## Verification
- `git config --file .gitconfig.template --get alias.skill-sync` parses and returns the expected dispatch string; `skill-publish` still parses.
- `tests/gitconfig_helper.Tests.ps1`: **62/62 pass**, including the `skill aliases` context and the ASCII-only check.

## Dependency
The wrapper this points at is added by claude-skills [#51](https://github.com/J-MaFf/claude-skills/pull/51). Until that merges and syncs to a machine, the alias errors visibly (missing script) rather than silently mis-syncing — so merge order isn't critical, but #51 first is cleanest.