### PR TITLE
fix: update stale branches-alias assertion in Integration.Tests.ps1

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -93,6 +93,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `Integration.Tests.ps1` no longer fails on the `branches` alias: the assertion expected
+  `2>/dev/null; done` but the alias ends with `2>/dev/null || true; done` (the `|| true`
+  was added so a failed per-branch create doesn't abort the loop). Updated the regex to match
+  ([#125](https://github.com/J-MaFf/gitconfig/issues/125))
 - Pester tests in the "Step 2b: Regenerate ~/.gitconfig on Template Change" context
   no longer fail with `The term 'Push-RemoteChange' is not recognized`. The
   `Push-RemoteChange` helper was defined directly in the `Context` body, which is not

--- a/tests/Integration.Tests.ps1
+++ b/tests/Integration.Tests.ps1
@@ -193,7 +193,7 @@ Describe "Git Aliases" {
         if ($gitconfigExists) {
             $result = & git config --get alias.branches
             $result | Should -Match "while read ref; do"
-            $result | Should -Match "2>/dev/null; done"
+            $result | Should -Match "2>/dev/null \|\| true; done"
         }
         else {
             Set-ItResult -Skipped -Because "Setup has not been run (no .gitconfig symlink found)"


### PR DESCRIPTION
Fixes #125

`Integration.Tests.ps1:196` asserted the `branches` alias matches `2>/dev/null; done`, but the alias ends with `2>/dev/null || true; done` (the `|| true` keeps a failed per-branch create from aborting the loop). The test failed on `main`, unrelated to any feature work.

## Change
- Update the regex to `2>/dev/null \|\| true; done` (escaped `||` for the `-Match` alternation operator).

## Verification
- `Integration.Tests.ps1`: **7 passed, 0 failed**, 11 skipped (setup-gated) on this machine — previously 1 failed.