### PR TITLE
feat: add git skill-sync-status alias

### DIFF
--- a/.gitconfig.template
+++ b/.gitconfig.template
@@ -39,6 +39,9 @@
     # after. Dispatches by OS like skill-publish; runs from any directory. The wrapper
     # lives in the claude-skills repo so future tweaks sync without touching this alias.
     skill-sync = "!f() { case \"$(uname -s)\" in MINGW*|MSYS*|CYGWIN*) powershell -NoProfile -ExecutionPolicy Bypass -File \"$USERPROFILE\\.claude\\skills\\scripts\\skill-sync.ps1\" ;; *) bash \"$HOME/.claude/skills/scripts/skill-sync.sh\" ;; esac; }; f"
+    # Show this machine's claude-skills sync state on demand: last background sync
+    # (from ~/.claude/skills-sync.log) + any unpublished local changes. Read-only.
+    skill-sync-status = "!f() { case \"$(uname -s)\" in MINGW*|MSYS*|CYGWIN*) powershell -NoProfile -ExecutionPolicy Bypass -File \"$USERPROFILE\\.claude\\skills\\scripts\\skill-sync-status.ps1\" ;; *) bash \"$HOME/.claude/skills/scripts/skill-sync-status.sh\" ;; esac; }; f"
     # Publish new/edited skills in the claude-skills repo (~/.claude/skills) via a
     # PR (its main is branch-protected): branches off main, prompts for a commit
     # message, makes a signed commit, opens a PR, and enables squash auto-merge.

--- a/README.md
+++ b/README.md
@@ -168,6 +168,7 @@ git selfupdate           # Pull this repo and reinstall ~/.gitconfig from the te
 
 ```bash
 git skill-sync           # Sync ~/.claude/skills: status -> pull --ff-only -> status
+git skill-sync-status    # Show ~/.claude/skills state: last background sync + unpublished local changes
 git skill-publish        # Publish new/edited skills via a PR (prompts for a message, auto-merges)
 ```
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `git skill-sync-status` alias — dispatches by OS to the claude-skills
+  `skill-sync-status.{sh,ps1}` helper: shows this machine's last background sync (from
+  `~/.claude/skills-sync.log`) plus any unpublished local changes. Sibling to `skill-sync`
+  and `skill-publish` ([#127](https://github.com/J-MaFf/gitconfig/issues/127))
 - `git alias` browser — when the interactive browser can't launch it no longer falls back
   to the static table **silently**: it prints a one-line reason to stderr (only when stderr
   is a TTY, so pipes/CI stay clean) — e.g. `textual` not installed, stdout not a TTY, or a

--- a/gitconfig_helper.py
+++ b/gitconfig_helper.py
@@ -225,6 +225,7 @@ ALIAS_METADATA = {
     "selfupdate": ("Maintenance", "Pull this repo and reinstall ~/.gitconfig from the template"),
     # Claude Skills
     "skill-sync": ("Claude Skills", "Sync ~/.claude/skills: status, pull --ff-only, status (flags unpublished local work)"),
+    "skill-sync-status": ("Claude Skills", "Show ~/.claude/skills sync state: last background sync + unpublished local changes"),
     "skill-publish": ("Claude Skills", "Publish new/edited skills (~/.claude/skills) via a PR with auto-merge"),
 }
 


### PR DESCRIPTION
Fixes #127

Adds `git skill-sync-status` as a sibling to `git skill-sync` / `git skill-publish`, dispatching by OS to the claude-skills `skill-sync-status.{sh,ps1}` helper (last background sync from the log + unpublished local changes). Closes the "not a git command" gap when users reach for it by analogy.

## Changes
- `.gitconfig.template` — `skill-sync-status` alias (Claude Skills group)
- `gitconfig_helper.py` — `ALIAS_METADATA` entry; `README.md` — list it; `docs/CHANGELOG.md` — entry

## Verification
- `git config --file .gitconfig.template --get alias.skill-sync-status` parses correctly.
- `tests/gitconfig_helper.Tests.ps1`: **62/62 pass**; description is ASCII.
- `get_git_aliases()` reads the live `~/.gitconfig`, so it lists the alias after a regen (`Initialize-GitConfig -Force` / next `git selfupdate` that pulls it).