### PR TITLE
feat: make git selfupdate convergent and resilient

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -71,6 +71,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- `git selfupdate` is now **convergent and resilient** so it reliably keeps `~/.gitconfig`
+  in sync. It regenerates whenever the installed config differs from the rendered template
+  (idempotent, checked every run) instead of only when a pull happened to change the template
+  — so it self-heals from a no-op pull, an already-current clone, or a hand-edited/deleted
+  config. The repo update is now best-effort: a dirty working tree, offline state, or
+  diverged history no longer aborts the run (it still converges `~/.gitconfig`), the pull is
+  `--ff-only`, and a failed `fetch --prune` is non-fatal. `generate_gitconfig` /
+  `Initialize-GitConfig.ps1` gained an idempotent skip (no rewrite/`.bak` churn when already
+  current) ([#129](https://github.com/J-MaFf/gitconfig/issues/129))
 - `git skill-sync` now dispatches by OS to the claude-skills `skill-sync.{sh,ps1}` wrapper
   (status → `pull --ff-only` → status) instead of running the bare `pull --ff-only`, so a
   skill edited on one machine but not yet published is surfaced before and after the sync.

--- a/scripts/shared/functions.sh
+++ b/scripts/shared/functions.sh
@@ -24,6 +24,19 @@ generate_gitconfig() {
         return 1
     fi
 
+    local generated_content
+    generated_content=$(cat "$template_path")
+    generated_content="${generated_content//\{\{REPO_PATH\}\}/$repo_root}"
+    generated_content="${generated_content//\{\{HOME_DIR\}\}/$home_dir}"
+
+    # Idempotent: if ~/.gitconfig already matches the rendered template, do nothing
+    # (no prompt, no backup, no write). This makes the auto-update convergent and
+    # safe to run on every login regardless of whether a pull happened.
+    if [ -f "$output_path" ] && [ "$(cat "$output_path")" = "$generated_content" ]; then
+        echo "[OK] .gitconfig already up to date (matches template)"
+        return 0
+    fi
+
     if [ -f "$output_path" ] && [ "$force" = "false" ]; then
         echo ".gitconfig already exists at: $output_path"
         read -p "Overwrite? (y/n) " -n 1 -r
@@ -38,11 +51,6 @@ generate_gitconfig() {
         cp "$output_path" "$output_path.bak"
         echo "[INFO] Backed up existing .gitconfig to .gitconfig.bak"
     fi
-
-    local generated_content
-    generated_content=$(cat "$template_path")
-    generated_content="${generated_content//\{\{REPO_PATH\}\}/$repo_root}"
-    generated_content="${generated_content//\{\{HOME_DIR\}\}/$home_dir}"
 
     echo "$generated_content" > "$output_path"
     echo "[OK] Generated .gitconfig"

--- a/scripts/shared/update-gitconfig.sh
+++ b/scripts/shared/update-gitconfig.sh
@@ -25,42 +25,35 @@ mkdir -p "$(dirname "$LOG_FILE")"
 
     cd "$REPO_PATH" || exit 1
 
-    log_message "Switching to main branch..."
-    SWITCH_RESULT=$(git checkout main 2>&1)
-    if [ $? -ne 0 ]; then
-        log_message "ERROR: Failed to switch to main branch"
-        log_message "Output: $SWITCH_RESULT"
-        exit 1
-    fi
-
-    log_message "Pulling latest changes from main..."
-    HEAD_BEFORE=$(git rev-parse HEAD 2>/dev/null)
-    PULL_RESULT=$(git pull 2>&1)
-    if [ $? -eq 0 ]; then
-        log_message "SUCCESS: git pull completed"
-        log_message "Output: $PULL_RESULT"
+    # --- Update the repo (best-effort; never fatal) ------------------------
+    # A dirty tree, offline state, or diverged history must not stop us from
+    # converging ~/.gitconfig below. --untracked-files=no: the log we just wrote
+    # under docs/ is untracked and must not count as "dirty" (untracked files
+    # don't block a checkout or ff-only pull).
+    if [ -n "$(git status --porcelain --untracked-files=no 2>/dev/null)" ]; then
+        log_message "WARN: working tree not clean; skipping pull (will still converge ~/.gitconfig)"
     else
-        log_message "ERROR: git pull failed"
-        log_message "Output: $PULL_RESULT"
-        exit 1
-    fi
-    HEAD_AFTER=$(git rev-parse HEAD 2>/dev/null)
-
-    # Reinstall ~/.gitconfig if the template changed during this pull.
-    # ~/.gitconfig is rendered from .gitconfig.template, so template changes
-    # download on pull but only take effect after regeneration.
-    if [ "$HEAD_BEFORE" != "$HEAD_AFTER" ] && \
-       [ -n "$(git diff --name-only "$HEAD_BEFORE" "$HEAD_AFTER" -- .gitconfig.template)" ]; then
-        log_message ".gitconfig.template changed; regenerating ~/.gitconfig..."
-        # shellcheck source=functions.sh
-        source "$SCRIPT_DIR/functions.sh"
-        if generate_gitconfig "$REPO_PATH" "$HOME" true; then
-            log_message "SUCCESS: ~/.gitconfig regenerated from template (previous saved to ~/.gitconfig.bak)"
-        else
-            log_message "ERROR: Failed to regenerate ~/.gitconfig from template"
+        if [ "$(git rev-parse --abbrev-ref HEAD 2>/dev/null)" != "main" ]; then
+            git checkout main >/dev/null 2>&1 || log_message "WARN: could not switch to main; pulling current branch"
         fi
+        log_message "Fetching and fast-forwarding..."
+        if git pull --ff-only; then
+            log_message "SUCCESS: repo up to date"
+        else
+            log_message "WARN: pull failed (offline or diverged); continuing with the local template"
+        fi
+    fi
+
+    # --- Converge ~/.gitconfig to the template (always) --------------------
+    # generate_gitconfig is idempotent: it writes only when the rendered template
+    # differs from ~/.gitconfig, so this self-heals from any state (stale,
+    # hand-edited, deleted, or a no-op pull) and is safe to run on every login.
+    # shellcheck source=functions.sh
+    source "$SCRIPT_DIR/functions.sh"
+    if generate_gitconfig "$REPO_PATH" "$HOME" true; then
+        log_message "SUCCESS: ~/.gitconfig converged to template"
     else
-        log_message "No .gitconfig.template changes; skipping regeneration"
+        log_message "ERROR: could not converge ~/.gitconfig from template"
     fi
 
     # Ensure the optional 'textual' dependency (for the interactive `git alias`
@@ -112,9 +105,8 @@ mkdir -p "$(dirname "$LOG_FILE")"
         done < <(git branch -vv)
         log_message "SUCCESS: Merged branches pruned"
     else
-        log_message "ERROR: git fetch --prune failed"
+        log_message "WARN: git fetch --prune failed (offline?); skipping prune"
         log_message "Output: $FETCH_RESULT"
-        exit 1
     fi
 
     log_message "Repository synchronization completed"

--- a/scripts/windows version/Initialize-GitConfig.ps1
+++ b/scripts/windows version/Initialize-GitConfig.ps1
@@ -83,6 +83,18 @@ try {
     $generatedContent = $templateContent
     $generatedContent = $generatedContent -replace '\{\{REPO_PATH\}\}', $repoPathForward
     $generatedContent = $generatedContent -replace '\{\{HOME_DIR\}\}', $homeDirForward
+
+    # Idempotent: skip backup/write when the installed config already matches the
+    # rendered template (newline-insensitive compare). Makes the auto-update
+    # convergent and avoids needless rewrites/.bak churn on every login.
+    if (Test-Path $outputPath) {
+        $normExisting = ((Get-Content $outputPath -Raw) -replace "`r`n", "`n").TrimEnd("`n")
+        $normGenerated = ($generatedContent -replace "`r`n", "`n").TrimEnd("`n")
+        if ($normExisting -eq $normGenerated) {
+            Write-Host "[OK] .gitconfig already up to date (matches template); no changes made" -ForegroundColor Green
+            exit 0
+        }
+    }
     
     # Backup existing file if it exists
     if (Test-Path $outputPath) {

--- a/scripts/windows version/Update-GitConfig.ps1
+++ b/scripts/windows version/Update-GitConfig.ps1
@@ -29,51 +29,42 @@ try {
     # Change to repo directory
     Push-Location $RepoPath
 
-    # Step 1: Switch to main branch
-    Write-Log "Switching to main branch..."
-    $switchResult = git checkout main 2>&1
-    if ($LASTEXITCODE -ne 0) {
-        Write-Log "ERROR: Failed to switch to main branch"
-        Write-Log "Output: $switchResult"
-        exit 1
-    }
-
-    # Step 2: Pull latest changes on main
-    Write-Log "Pulling latest changes from main..."
-    $headBefore = (git rev-parse HEAD 2>$null)
-    $pullResult = git pull 2>&1
-    if ($LASTEXITCODE -eq 0) {
-        Write-Log "SUCCESS: git pull completed on main"
-        Write-Log "Output: $pullResult"
+    # Step 1+2: Update the repo (best-effort; never fatal). A dirty tree, offline
+    # state, or diverged history must not stop the convergence step below.
+    # --untracked-files=no: the log we just wrote under docs/ is untracked and must
+    # not count as "dirty" (untracked files don't block a checkout or ff-only pull).
+    if (git status --porcelain --untracked-files=no 2>$null) {
+        Write-Log "WARN: working tree not clean; skipping pull (will still converge ~/.gitconfig)"
     }
     else {
-        Write-Log "ERROR: git pull failed with exit code $LASTEXITCODE"
-        Write-Log "Output: $pullResult"
-    }
-    $headAfter = (git rev-parse HEAD 2>$null)
-
-    # Step 2b: Reinstall ~/.gitconfig if the template changed during this pull.
-    # ~/.gitconfig is rendered from .gitconfig.template, so template changes
-    # download on pull but only take effect after regeneration.
-    if ($headBefore -ne $headAfter) {
-        $templateChanged = git diff --name-only $headBefore $headAfter -- .gitconfig.template
-        if ($templateChanged) {
-            Write-Log ".gitconfig.template changed; regenerating ~/.gitconfig..."
-            $initScript = Join-Path $PSScriptRoot "Initialize-GitConfig.ps1"
-            & $initScript -Force 2>&1 | ForEach-Object { Write-Log $_ }
-            if ($LASTEXITCODE -eq 0) {
-                Write-Log "SUCCESS: ~/.gitconfig regenerated from template (previous saved to ~/.gitconfig.bak)"
-            }
-            else {
-                Write-Log "ERROR: Failed to regenerate ~/.gitconfig from template (exit code $LASTEXITCODE)"
-            }
+        if ((git rev-parse --abbrev-ref HEAD 2>$null) -ne "main") {
+            git checkout main 2>&1 | Out-Null
+            if ($LASTEXITCODE -ne 0) { Write-Log "WARN: could not switch to main; pulling current branch" }
+        }
+        Write-Log "Fetching and fast-forwarding..."
+        $pullResult = git pull --ff-only 2>&1
+        if ($LASTEXITCODE -eq 0) {
+            Write-Log "SUCCESS: repo up to date"
         }
         else {
-            Write-Log "No .gitconfig.template changes; skipping regeneration"
+            Write-Log "WARN: pull failed (offline or diverged); continuing with the local template. Output: $pullResult"
         }
     }
+
+    # Step 2b: Converge ~/.gitconfig to the template (always). Initialize-GitConfig
+    # is idempotent - it writes only when the rendered template differs from
+    # ~/.gitconfig - so this self-heals from any state (stale, hand-edited, deleted,
+    # or a no-op pull) and is safe to run on every login.
+    Write-Log "Converging ~/.gitconfig to template..."
+    $initScript = Join-Path $PSScriptRoot "Initialize-GitConfig.ps1"
+    # *>&1 (not 2>&1): Initialize-GitConfig reports via Write-Host (information
+    # stream), so capture all streams to fold its output into our log.
+    & $initScript -Force *>&1 | ForEach-Object { Write-Log $_ }
+    if ($LASTEXITCODE -eq 0) {
+        Write-Log "SUCCESS: ~/.gitconfig converged to template"
+    }
     else {
-        Write-Log "No new commits pulled; skipping regeneration"
+        Write-Log "ERROR: convergence failed (exit code $LASTEXITCODE)"
     }
 
     # Step 2c: Ensure the optional 'textual' dependency (for the interactive

--- a/tests/Update-GitConfig.Tests.ps1
+++ b/tests/Update-GitConfig.Tests.ps1
@@ -24,6 +24,7 @@ BeforeAll {
         git init 2>&1 | Out-Null
         git config user.email "test@example.com"
         git config user.name "Test User"
+        git config commit.gpgsign false   # fake HOME has no signing key; don't sign
 
         # Create initial commit on main
         New-Item -Path "docs" -ItemType Directory -Force | Out-Null
@@ -49,6 +50,17 @@ BeforeAll {
         git init --bare 2>&1 | Out-Null
         Pop-Location
     }
+
+    # The convergence step now runs on every invocation and writes ~/.gitconfig.
+    # Redirect HOME to a throwaway dir for the whole suite so tests never touch the
+    # developer's real ~/.gitconfig. (Step 2b overrides this per-test with its own
+    # fake home using different variables, so there is no collision.)
+    $script:realUserProfile = $env:USERPROFILE
+    $script:realHome = $env:HOME
+    $script:fakeHomeGlobal = Join-Path ([System.IO.Path]::GetTempPath()) ("ugc-home-" + [guid]::NewGuid().ToString("N"))
+    New-Item -ItemType Directory -Force -Path $script:fakeHomeGlobal | Out-Null
+    $env:USERPROFILE = $script:fakeHomeGlobal
+    $env:HOME = $script:fakeHomeGlobal
 }
 
 Describe "Update-GitConfig.ps1" {
@@ -186,8 +198,8 @@ Describe "Update-GitConfig.ps1" {
             # Read log content
             $logContent = Get-Content $script:logFile -Raw
 
-            # Verify log message
-            $logContent | Should -Match "Switching to main branch"
+            # Verify the fetch/fast-forward step ran after switching to main
+            $logContent | Should -Match "Fetching and fast-forwarding"
         }
 
         It "Should handle failed branch switch gracefully" {
@@ -202,8 +214,8 @@ Describe "Update-GitConfig.ps1" {
             # Read log content
             $logContent = Get-Content $script:logFile -Raw
 
-            # Verify error was logged
-            $logContent | Should -Match "ERROR: Failed to switch to main branch"
+            # Verify the failed switch was logged as a warning (non-fatal now)
+            $logContent | Should -Match "WARN: could not switch to main"
         }
     }
 
@@ -222,6 +234,7 @@ Describe "Update-GitConfig.ps1" {
                 git clone $remoteRepo . 2>&1 | Out-Null
                 git config user.email "test@example.com"
                 git config user.name "Test User"
+                git config commit.gpgsign false   # fake HOME has no signing key
 
                 # Create initial commit
                 New-Item -Path "docs" -ItemType Directory -Force | Out-Null
@@ -261,8 +274,8 @@ Describe "Update-GitConfig.ps1" {
             # Read log content
             $logContent = Get-Content $script:logFile -Raw
 
-            # Verify pull was attempted
-            $logContent | Should -Match "Pulling latest changes from main"
+            # Verify the fetch/fast-forward step ran
+            $logContent | Should -Match "Fetching and fast-forwarding"
         }
 
         It "Should log pull success" {
@@ -272,8 +285,8 @@ Describe "Update-GitConfig.ps1" {
             # Read log content
             $logContent = Get-Content $script:logFile -Raw
 
-            # Verify success message (either "Already up to date" or "SUCCESS: git pull completed")
-            $logContent | Should -Match "(SUCCESS: git pull completed|Already up to date)"
+            # Verify success message
+            $logContent | Should -Match "SUCCESS: repo up to date"
         }
 
         It "Should handle pull failure gracefully" {
@@ -288,8 +301,8 @@ Describe "Update-GitConfig.ps1" {
             # Read log content
             $logContent = Get-Content $script:logFile -Raw
 
-            # Verify error was logged
-            $logContent | Should -Match "ERROR: git pull failed"
+            # Verify the failed pull was logged as a warning (non-fatal now)
+            $logContent | Should -Match "WARN: pull failed"
         }
     }
 
@@ -577,8 +590,8 @@ Describe "Update-GitConfig.ps1" {
 
             # Verify all steps were logged
             $logContent | Should -Match "Starting git repository synchronization"
-            $logContent | Should -Match "Switching to main branch"
-            $logContent | Should -Match "Pulling latest changes from main"
+            $logContent | Should -Match "Fetching and fast-forwarding"
+            $logContent | Should -Match "SUCCESS: ~/.gitconfig converged to template"
             $logContent | Should -Match "Pruning merged branches"
             $logContent | Should -Match "SUCCESS: git fetch --prune completed"
             $logContent | Should -Match "Deleted merged branch: merged-feature"
@@ -662,24 +675,48 @@ Describe "Update-GitConfig.ps1" {
             }
         }
 
-        It "Should regenerate ~/.gitconfig when the template changed" {
-            Push-RemoteChange -File ".gitconfig.template" -Content "[core]`n`teditor = vim`n" -Message "Change template"
-
-            & $script:scriptPath -RepoPath $script:testRepo 2>&1 | Out-Null
-
-            $logContent = Get-Content $script:logFile -Raw
-            $logContent | Should -Match "regenerating ~/.gitconfig"
-            (Join-Path $script:fakeHome ".gitconfig") | Should -Exist
-        }
-
-        It "Should not regenerate when no template change occurred" {
+        It "Should converge ~/.gitconfig even when the pull brings no template change" {
+            # The classic failure mode: a no-op / docs-only pull used to skip regen,
+            # leaving ~/.gitconfig stale. Convergence now regenerates it regardless.
             Push-RemoteChange -File "README.md" -Content "# updated readme" -Message "Docs only"
 
             & $script:scriptPath -RepoPath $script:testRepo 2>&1 | Out-Null
 
             $logContent = Get-Content $script:logFile -Raw
-            $logContent | Should -Match "skipping regeneration"
-            (Join-Path $script:fakeHome ".gitconfig") | Should -Not -Exist
+            $logContent | Should -Match "converged to template"
+            (Join-Path $script:fakeHome ".gitconfig") | Should -Exist
         }
+
+        It "Should replace a stale ~/.gitconfig that differs from the template" {
+            $cfg = Join-Path $script:fakeHome ".gitconfig"
+            Set-Content -Path $cfg -Value "STALE-MARKER-DO-NOT-KEEP"
+
+            & $script:scriptPath -RepoPath $script:testRepo 2>&1 | Out-Null
+
+            (Get-Content $cfg -Raw) | Should -Not -Match "STALE-MARKER-DO-NOT-KEEP"
+            "$cfg.bak" | Should -Exist   # the stale version was backed up
+        }
+
+        It "Should not rewrite ~/.gitconfig when it already matches the template" {
+            # First run creates it from the template; the second run must be a no-op.
+            & $script:scriptPath -RepoPath $script:testRepo 2>&1 | Out-Null
+            $cfg = Join-Path $script:fakeHome ".gitconfig"
+            if (Test-Path "$cfg.bak") { Remove-Item "$cfg.bak" -Force }
+            if (Test-Path $script:logFile) { Remove-Item $script:logFile -Force }
+
+            & $script:scriptPath -RepoPath $script:testRepo 2>&1 | Out-Null
+
+            $logContent = Get-Content $script:logFile -Raw
+            $logContent | Should -Match "already up to date"
+            "$cfg.bak" | Should -Not -Exist   # no rewrite => no backup made
+        }
+    }
+}
+
+AfterAll {
+    $env:USERPROFILE = $script:realUserProfile
+    $env:HOME = $script:realHome
+    if ($script:fakeHomeGlobal -and (Test-Path $script:fakeHomeGlobal)) {
+        Remove-Item $script:fakeHomeGlobal -Recurse -Force -ErrorAction SilentlyContinue
     }
 }


### PR DESCRIPTION
Fixes #129

`git selfupdate` "doesn't always work" because regeneration of `~/.gitconfig` is **delta-driven**: it only fires when a pull moves `HEAD` *and* the diff touches `.gitconfig.template`. So the installed config silently goes stale after a no-op pull, an already-current clone (e.g. commits merged locally), or a hand-edited/deleted config. Several steps also hard-abort the whole run before regen.

## Changes
**Convergent regen (core):** `Update-GitConfig.ps1` and `shared/update-gitconfig.sh` now regenerate whenever the installed `~/.gitconfig` differs from the rendered template — checked **every run**, independent of the pull. Self-heals from any state; idempotent. `generate_gitconfig` / `Initialize-GitConfig.ps1` gained an idempotent skip (no `.bak` churn when already current; newline-insensitive compare on Windows).

**Resilience (non-fatal):** skip the pull when the working tree has tracked changes; `checkout main` and `pull --ff-only` are best-effort; `~/.gitconfig` still converges regardless of pull outcome (works offline). A failed `fetch --prune` no longer `exit 1`s.

## Bugs caught while testing
- The dirty check counted the freshly-written `docs/update-gitconfig.log` → `--untracked-files=no` so untracked files don't read as dirty.
- `Update-GitConfig` captured `Initialize` via `2>&1`, but `Initialize` reports through `Write-Host` (information stream) → use `*>&1` so its output reaches the log.

## Testing
- Rewrote `Update-GitConfig.Tests` **Step 2b** for convergent behavior (converges on a no-op pull, replaces a stale config, idempotent when matching); updated Step 1/2/Integration assertions to the new log messages; made the suite hermetic (HOME redirect so convergence never touches the real `~/.gitconfig`) and set `commit.gpgsign=false` in the two setups that lacked it.
- Verified the **nix path** end-to-end: fresh→converge, unchanged→idempotent (no `.bak`), stale→regenerate+backup, prune failure non-fatal.
- **Full suite: 175 passed, 1 failed, 30 skipped.** The one failure is a **pre-existing stale test** unrelated to this change (filed as [#130](https://github.com/J-MaFf/gitconfig/issues/130)).

## Per-machine effect
Once this lands, `git selfupdate` becomes self-healing: any machine whose `~/.gitconfig` is out of sync with the template (for any reason) is corrected on the next run, no manual `Initialize-GitConfig -Force` needed.