### PR TITLE
ci: add Claude Code GitHub workflow

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,0 +1,47 @@
+name: Claude Code
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+  issues:
+    types: [opened, assigned]
+  pull_request_review:
+    types: [submitted]
+
+jobs:
+  claude:
+    # Only run when "@claude" is mentioned in the relevant comment, review, issue body, or issue title.
+    if: |
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
+      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+    # ubuntu-latest: the action installs the Claude CLI here reliably (it cannot on
+    # windows-latest). Windows-specific test execution lives in windows-tests.yml.
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+      id-token: write
+      actions: read # Required for Claude to read CI results on PRs
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+
+      - name: Run Claude Code
+        uses: anthropics/claude-code-action@v1
+        with:
+          # Authenticate with a Claude Pro/Max subscription OAuth token (generated via `claude setup-token`)
+          # instead of a pay-as-you-go ANTHROPIC_API_KEY. Stored as the CLAUDE_CODE_OAUTH_TOKEN repo secret.
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+
+          # Optional configuration (uncomment to customize):
+          # trigger_phrase: "@claude"
+          # claude_args: |
+          #   --model claude-sonnet-4-6
+          #   --max-turns 10


### PR DESCRIPTION
## Add Claude Code GitHub workflow

Adds `.github/workflows/claude.yml` so that mentioning `@claude` in an issue,
PR comment, or review triggers the [Claude Code action](https://github.com/anthropics/claude-code-action).

This is the same workflow already proven in `winget-app-setup`. It authenticates
with a Claude Pro/Max subscription **OAuth token** (`CLAUDE_CODE_OAUTH_TOKEN` repo
secret) rather than a pay-as-you-go API key, so there is no metered per-run billing.

### Required follow-up
`@claude` will not respond until the `CLAUDE_CODE_OAUTH_TOKEN` secret is set on this
repo. That secret is being rolled out separately.

> Opened directly as a PR (no tracking issue) because direct commits to the default
> branch are blocked.
