### PR TITLE
fix: update stale absolute-paths assertion in Initialize-GitConfig.Tests

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -106,6 +106,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `Initialize-GitConfig.Tests.ps1` ("Generated config should contain absolute paths") no
+  longer fails: its regex expected a literal `python <abs-path>/gitconfig_helper.py`, but the
+  helper aliases were refactored to a `for p in py python3 python; do … exec "$p" <path>`
+  loop, so the path is invoked via the `$p` variable. Updated the assertion to match an
+  absolute path to `gitconfig_helper.py` (Unix or Windows)
+  ([#130](https://github.com/J-MaFf/gitconfig/issues/130))
 - `Integration.Tests.ps1` no longer fails on the `branches` alias: the assertion expected
   `2>/dev/null; done` but the alias ends with `2>/dev/null || true; done` (the `|| true`
   was added so a failed per-branch create doesn't abort the loop). Updated the regex to match

--- a/tests/Initialize-GitConfig.Tests.ps1
+++ b/tests/Initialize-GitConfig.Tests.ps1
@@ -96,9 +96,11 @@ Describe "Initialize-GitConfig.ps1" {
 
         It "Generated config should contain absolute paths" {
             $generatedContent = Get-Content $script:outputPath -Raw
-            # Should have actual repository path, not relative or placeholder
-            # Matches both Unix (/path/to/gitconfig_helper.py) and Windows (C:/path/to/gitconfig_helper.py)
-            $generatedContent | Should -Match 'python\s+[A-Za-z]?:?/.*gitconfig_helper\.py'
+            # The helper is invoked as `exec "$p" <abs-path>/gitconfig_helper.py` (the
+            # py/python3/python loop), so assert an absolute path to it - placeholder
+            # substituted, not relative. Matches Unix (/path/to/gitconfig_helper.py)
+            # and Windows (C:/path/to/gitconfig_helper.py).
+            $generatedContent | Should -Match '(?:[A-Za-z]:)?/[^\s"]*gitconfig_helper\.py'
         }
 
         It "Generated config should preserve [include] section" {


### PR DESCRIPTION
Fixes #130

The assertion expected a literal `python\s+...gitconfig_helper\.py`, but the helper aliases were refactored to a `for p in py python3 python; do … exec "$p" <abs-path>/gitconfig_helper.py` loop — so the path is invoked via the `$p` variable, never a literal `python <path>`. The regex couldn't match, so the test failed on `main` independent of any feature work.

## Change
- Update the regex to `(?:[A-Za-z]:)?/[^\s"]*gitconfig_helper\.py` — asserts an absolute path to the helper (Unix or Windows), which is the test's actual intent (placeholder substituted, not relative).

## Verification
- `Initialize-GitConfig.Tests.ps1`: **18 passed, 0 failed** (was 17/1).

With this, the full suite is green (the last remaining pre-existing failure).