### PR TITLE
fix(tests): update stale python\s+ pattern in forward-slashes test

### DIFF
--- a/tests/Initialize-GitConfig.Tests.ps1
+++ b/tests/Initialize-GitConfig.Tests.ps1
@@ -81,10 +81,13 @@ Describe "Initialize-GitConfig.ps1" {
 
         It "Generated config should use forward slashes in paths" {
             $generatedContent = Get-Content $script:outputPath -Raw
-            # Git config requires forward slashes, not backslashes
-            if ($generatedContent -match 'python\s+([^\s]+)') {
-                $pythonPath = $matches[1]
-                $pythonPath | Should -Not -Match '\\'
+            # Git config requires forward slashes, not backslashes.
+            # The helper is now invoked via the py/python3/python loop as
+            # `exec "$p" <path>/gitconfig_helper.py`, so match the absolute
+            # path directly (same pattern as "should contain absolute paths").
+            if ($generatedContent -match '((?:[A-Za-z]:)?/[^\s"]*gitconfig_helper\.py)') {
+                $helperPath = $matches[1]
+                $helperPath | Should -Not -Match '\\'
             }
         }
 


### PR DESCRIPTION
The two main test assertions from #99 were already fixed in the codebase. This PR fixes the remaining stale `python\s+` regex in the "Generated config should use forward slashes in paths" test, which was passing vacuously after the py-launcher alias change (#92).

Updates the match pattern to `((?:[A-Za-z]:)?/[^\s"]*gitconfig_helper\.py)` — consistent with the already-fixed "should contain absolute paths" assertion — so the forward-slash check is live again.

Closes #99

Generated with [Claude Code](https://claude.ai/code)