### PR TITLE
ci: load git-policies into CLAUDE.md at runtime

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -33,6 +33,24 @@ jobs:
         with:
           fetch-depth: 1
 
+      # Pull the shared git-policies conventions into CLAUDE.md so @claude follows
+      # them on every run. The rules live in the private claude-skills repo and are
+      # published to this public URL; we fetch them fresh each run (no token needed).
+      # Soft-fails: if the fetch is unavailable, the job still runs without them.
+      - name: Load git-policies into CLAUDE.md
+        run: |
+          url="https://raw.githubusercontent.com/J-MaFf/J-MaFf.github.io/main/claude/git-policies.md"
+          if curl -fsSL "$url" -o /tmp/git-policies.md; then
+            {
+              printf '\n<!-- BEGIN git-policies (fetched at runtime from %s) -->\n' "$url"
+              cat /tmp/git-policies.md
+              printf '\n<!-- END git-policies -->\n'
+            } >> CLAUDE.md
+            echo "Loaded git-policies into CLAUDE.md ($(wc -l < /tmp/git-policies.md) lines)."
+          else
+            echo "::warning::Could not fetch git-policies from $url; proceeding without it."
+          fi
+
       - name: Run Claude Code
         uses: anthropics/claude-code-action@v1
         with:


### PR DESCRIPTION
Fixes #135

Adds a "Load git-policies into CLAUDE.md" step to the Claude Code workflow. It curls the public git-policies mirror and appends it to `CLAUDE.md` before `claude-code-action` runs, so `@claude` follows our conventions (issue-first, branch naming, `Fixes #N`, `--assignee J-MaFf --label`, squash template, etc.) on every run.

- Source of truth: private `claude-skills` `git-policies/SKILL.md`
- Published (sanitized) to: `raw.githubusercontent.com/J-MaFf/J-MaFf.github.io/main/claude/git-policies.md`
- Fetched fresh each run — **no token** needed on this repo
- **Soft-fails:** if the fetch is unavailable, the job warns and still runs

Pilot for the rollout to all repos. Takes effect once the public mirror is live (claude-skills#54 merged + `PAGES_SYNC_TOKEN` set).

## Testing
- `claude.yml` YAML parses; the new run step passes `bash -n`