### PR TITLE
feat: add `git skill list` alias to list installed skills

### DIFF
--- a/.gitconfig.template
+++ b/.gitconfig.template
@@ -30,9 +30,10 @@
 	main = !"f() { for p in py python3 python; do command -v \"$p\" >/dev/null 2>&1 && \"$p\" -c '' >/dev/null 2>&1 && exec \"$p\" {{REPO_PATH}}/gitconfig_helper.py switch_to_main \"$@\"; done; echo 'No working Python found (tried py, python3, python)' >&2; return 1; }; f"
 	# Manage machine-specific git configuration
 	localconfig = !git config --file ~/.gitconfig.local
-	# Read-only skill subcommands operating on ~/.claude/skills.
-	#   git skill list   List installed skills (immediate subdirs holding a SKILL.md)
-	skill = "!f() { case \"$1\" in list) d=\"$HOME/.claude/skills\"; [ -d \"$d\" ] || { echo \"git skill: skills directory not found: $d\" >&2; return 1; }; n=0; for s in \"$d\"/*/; do [ -f \"${s}SKILL.md\" ] || continue; b=${s%/}; echo \"${b##*/}\"; n=1; done; [ \"$n\" = 1 ] || { echo \"git skill: no skills found in $d\" >&2; return 1; } ;; \"\"|-h|--help|help) echo \"usage: git skill list\" >&2 ;; *) echo \"git skill: unknown subcommand '$1' (try: list)\" >&2; return 1 ;; esac; }; f"
+	# Read-only skill subcommands operating on ~/.claude/skills (dispatches to the
+	# Python helper). `git skill list` shows each installed skill's name, a one-line
+	# description from its SKILL.md, and its last-updated date as a rich table.
+	skill = !"f() { for p in py python3 python; do command -v \"$p\" >/dev/null 2>&1 && \"$p\" -c '' >/dev/null 2>&1 && exec \"$p\" {{REPO_PATH}}/gitconfig_helper.py skill \"$@\"; done; echo 'No working Python found (tried py, python3, python)' >&2; return 1; }; f"
 	# Sync the claude-skills repo (~/.claude/skills) on demand: show status, pull
 	# --ff-only, show status again, so unpublished local work is surfaced before and
 	# after. Dispatches by OS like skill-publish; runs from any directory. The wrapper

--- a/.gitconfig.template
+++ b/.gitconfig.template
@@ -30,6 +30,9 @@
 	main = !"f() { for p in py python3 python; do command -v \"$p\" >/dev/null 2>&1 && \"$p\" -c '' >/dev/null 2>&1 && exec \"$p\" {{REPO_PATH}}/gitconfig_helper.py switch_to_main \"$@\"; done; echo 'No working Python found (tried py, python3, python)' >&2; return 1; }; f"
 	# Manage machine-specific git configuration
 	localconfig = !git config --file ~/.gitconfig.local
+	# Read-only skill subcommands operating on ~/.claude/skills.
+	#   git skill list   List installed skills (immediate subdirs holding a SKILL.md)
+	skill = "!f() { case \"$1\" in list) d=\"$HOME/.claude/skills\"; [ -d \"$d\" ] || { echo \"git skill: skills directory not found: $d\" >&2; return 1; }; n=0; for s in \"$d\"/*/; do [ -f \"${s}SKILL.md\" ] || continue; b=${s%/}; echo \"${b##*/}\"; n=1; done; [ \"$n\" = 1 ] || { echo \"git skill: no skills found in $d\" >&2; return 1; } ;; \"\"|-h|--help|help) echo \"usage: git skill list\" >&2 ;; *) echo \"git skill: unknown subcommand '$1' (try: list)\" >&2; return 1 ;; esac; }; f"
 	# Sync the claude-skills repo (~/.claude/skills) on demand: show status, pull
 	# --ff-only, show status again, so unpublished local work is surfaced before and
 	# after. Dispatches by OS like skill-publish; runs from any directory. The wrapper

--- a/README.md
+++ b/README.md
@@ -167,6 +167,7 @@ git selfupdate           # Pull this repo and reinstall ~/.gitconfig from the te
 **Claude Skills**
 
 ```bash
+git skill list           # List installed skills in ~/.claude/skills
 git skill-sync           # Sync ~/.claude/skills: status -> pull --ff-only -> status
 git skill-sync-status    # Show ~/.claude/skills state: last background sync + unpublished local changes
 git skill-publish        # Publish new/edited skills via a PR (prompts for a message, auto-merges)

--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ git selfupdate           # Pull this repo and reinstall ~/.gitconfig from the te
 **Claude Skills**
 
 ```bash
-git skill list           # List installed skills in ~/.claude/skills
+git skill list           # Table of installed skills: name, description, last updated
 git skill-sync           # Sync ~/.claude/skills: status -> pull --ff-only -> status
 git skill-sync-status    # Show ~/.claude/skills state: last background sync + unpublished local changes
 git skill-publish        # Publish new/edited skills via a PR (prompts for a message, auto-merges)

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `.gitconfig.template` — new `git skill list` alias that lists installed skills
+  (immediate subdirectories of `~/.claude/skills` containing a `SKILL.md`). Implemented
+  as a `skill` subcommand dispatcher so future `git skill <subcommand>` forms can be added.
+  Registered in `gitconfig_helper.py`'s `ALIAS_METADATA` under "Claude Skills" so it appears
+  in the `git alias` browser ([#140](https://github.com/J-MaFf/gitconfig/issues/140))
+
 ### Fixed
 
 - `scripts/mac version/initialize-local-config.sh` — always write `[gpg "ssh"]

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,10 +10,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - `.gitconfig.template` — new `git skill list` alias that lists installed skills
-  (immediate subdirectories of `~/.claude/skills` containing a `SKILL.md`). Implemented
-  as a `skill` subcommand dispatcher so future `git skill <subcommand>` forms can be added.
-  Registered in `gitconfig_helper.py`'s `ALIAS_METADATA` under "Claude Skills" so it appears
-  in the `git alias` browser ([#140](https://github.com/J-MaFf/gitconfig/issues/140))
+  (immediate subdirectories of `~/.claude/skills` containing a `SKILL.md`) as a `rich`
+  table showing each skill's name, a one-line description parsed from its `SKILL.md`
+  frontmatter, and the date it was last updated (last commit touching the skill, falling
+  back to the file mtime). Implemented as a `skill` subcommand dispatcher in
+  `gitconfig_helper.py` (so future `git skill <subcommand>` forms can be added) and
+  registered in `ALIAS_METADATA` under "Claude Skills" so it appears in the `git alias`
+  browser ([#140](https://github.com/J-MaFf/gitconfig/issues/140))
 
 ### Fixed
 

--- a/gitconfig_helper.py
+++ b/gitconfig_helper.py
@@ -15,6 +15,7 @@ import shutil
 try:
     from rich.console import Console
     from rich.table import Table
+    from rich.markup import escape
 except ImportError:
     print("Error: the 'rich' library is not installed.")
     print("Run the install script for your platform, or: pip install rich")
@@ -224,7 +225,7 @@ ALIAS_METADATA = {
     "localconfig": ("Maintenance", "Edit machine-specific git config (~/.gitconfig.local)"),
     "selfupdate": ("Maintenance", "Pull this repo and reinstall ~/.gitconfig from the template"),
     # Claude Skills
-    "skill": ("Claude Skills", "List installed skills in ~/.claude/skills (git skill list)"),
+    "skill": ("Claude Skills", "List installed skills in ~/.claude/skills with descriptions and last-updated dates (git skill list)"),
     "skill-sync": ("Claude Skills", "Sync ~/.claude/skills: status, pull --ff-only, status (flags unpublished local work)"),
     "skill-sync-status": ("Claude Skills", "Show ~/.claude/skills sync state: last background sync + unpublished local changes"),
     "skill-publish": ("Claude Skills", "Publish new/edited skills (~/.claude/skills) via a PR with auto-merge"),
@@ -278,6 +279,134 @@ def get_git_aliases():
     order = {cat: i for i, cat in enumerate(CATEGORY_ORDER)}
     aliases.sort(key=lambda a: (order.get(a[2], len(order)), a[0]))
     return aliases
+
+
+def _read_skill_description(skill_md_path):
+    """Return the one-line 'description' from a SKILL.md YAML frontmatter block.
+
+    Handles both a single-line 'description: text' and a folded/literal block
+    scalar ('description: >' or '|' followed by indented lines). Returns '' when
+    there is no frontmatter or no description. Whitespace is collapsed to single
+    spaces and any surrounding quotes are stripped.
+    """
+    try:
+        with open(skill_md_path, encoding="utf-8", errors="replace") as handle:
+            lines = handle.read().splitlines()
+    except OSError:
+        return ""
+
+    if not lines or lines[0].strip() != "---":
+        return ""
+
+    # Collect the frontmatter lines up to the closing '---'.
+    front = []
+    for line in lines[1:]:
+        if line.strip() == "---":
+            break
+        front.append(line)
+
+    for i, line in enumerate(front):
+        match = re.match(r"\s*description\s*:\s*(.*)$", line)
+        if not match:
+            continue
+        value = match.group(1).strip()
+        # Block scalar (empty value or a '>'/'|' indicator): gather the following
+        # blank or more-indented lines until the next top-level key.
+        if value in ("", ">", "|", ">-", "|-", ">+", "|+"):
+            collected = []
+            for cont in front[i + 1:]:
+                if cont.strip() == "":
+                    continue
+                if re.match(r"\s", cont):
+                    collected.append(cont.strip())
+                else:
+                    break
+            value = " ".join(collected)
+        value = value.strip()
+        if len(value) >= 2 and value[0] in "\"'" and value[-1] == value[0]:
+            value = value[1:-1]
+        return re.sub(r"\s+", " ", value).strip()
+
+    return ""
+
+
+def _skill_last_updated(skills_dir, name, skill_md_path):
+    """Return the date a skill was last updated as 'YYYY-MM-DD'.
+
+    Prefers the last commit that touched the skill directory (when the skills
+    directory is a git repo); falls back to the SKILL.md modification time, or
+    'unknown' if neither is available.
+    """
+    result = run_git("-C", skills_dir, "log", "-1", "--format=%cs", "--", name)
+    if result.returncode == 0 and result.stdout.strip():
+        return result.stdout.strip()
+    try:
+        import datetime
+
+        return datetime.date.fromtimestamp(os.path.getmtime(skill_md_path)).isoformat()
+    except OSError:
+        return "unknown"
+
+
+def list_skills():
+    """Print installed Claude skills (~/.claude/skills) as a rich table.
+
+    A skill is an immediate subdirectory containing a SKILL.md. Each row shows
+    the skill name, a one-line description from the SKILL.md frontmatter, and the
+    date it was last updated (last commit touching it, else the file mtime).
+    """
+    console = Console()
+    skills_dir = os.path.join(os.path.expanduser("~"), ".claude", "skills")
+    if not os.path.isdir(skills_dir):
+        console.print(f"[red]Skills directory not found: {skills_dir}[/red]")
+        return 1
+
+    rows = []
+    for name in sorted(os.listdir(skills_dir)):
+        skill_md = os.path.join(skills_dir, name, "SKILL.md")
+        if not os.path.isfile(skill_md):
+            continue
+        description = _read_skill_description(skill_md)
+        if len(description) > 100:
+            description = description[:99].rstrip() + "..."
+        updated = _skill_last_updated(skills_dir, name, skill_md)
+        rows.append((name, description, updated))
+
+    if not rows:
+        console.print(f"[yellow]No skills found in {skills_dir}[/yellow]")
+        return 0
+
+    table = Table(title="Claude Skills", show_lines=True, header_style="bold yellow")
+    table.add_column("Skill", justify="left", style="cyan", no_wrap=True)
+    table.add_column("Description", justify="left", style="white")
+    table.add_column("Updated", justify="left", style="green", no_wrap=True)
+    for name, description, updated in rows:
+        table.add_row(
+            name, escape(description) if description else "(no description)", updated
+        )
+
+    console.print(table)
+    console.print(f"\n[dim]{len(rows)} skills in {skills_dir}[/dim]")
+    return 0
+
+
+def skill(args):
+    """Dispatch a `git skill <subcommand>` invocation.
+
+    Subcommands:
+      list   List installed skills in ~/.claude/skills (name, description,
+             last-updated date) as a table.
+    """
+    sub = args[0] if args else ""
+    if sub == "list":
+        return list_skills()
+    if sub in ("", "help", "-h", "--help"):
+        Console().print("usage: git skill list")
+        return 0
+    Console(stderr=True).print(
+        f"[red]git skill: unknown subcommand '{sub}' (try: list)[/red]"
+    )
+    return 1
 
 
 # Issue labels -> branch-name prefix, per the git-policies branch conventions.
@@ -976,6 +1105,8 @@ if __name__ == "__main__":
             sys.exit(switch_to_main())
         elif function_name == "update_all_main":
             sys.exit(update_all_main())
+        elif function_name == "skill":
+            sys.exit(skill(sys.argv[2:]))
         else:
             print(f"Function {function_name} not found.")
     else:

--- a/gitconfig_helper.py
+++ b/gitconfig_helper.py
@@ -224,6 +224,7 @@ ALIAS_METADATA = {
     "localconfig": ("Maintenance", "Edit machine-specific git config (~/.gitconfig.local)"),
     "selfupdate": ("Maintenance", "Pull this repo and reinstall ~/.gitconfig from the template"),
     # Claude Skills
+    "skill": ("Claude Skills", "List installed skills in ~/.claude/skills (git skill list)"),
     "skill-sync": ("Claude Skills", "Sync ~/.claude/skills: status, pull --ff-only, status (flags unpublished local work)"),
     "skill-sync-status": ("Claude Skills", "Show ~/.claude/skills sync state: last background sync + unpublished local changes"),
     "skill-publish": ("Claude Skills", "Publish new/edited skills (~/.claude/skills) via a PR with auto-merge"),

--- a/tests/GitconfigTemplate.Tests.ps1
+++ b/tests/GitconfigTemplate.Tests.ps1
@@ -10,6 +10,7 @@ BeforeDiscovery {
         @{ Alias = 'cleanup' }
         @{ Alias = 'main' }
         @{ Alias = 'start' }
+        @{ Alias = 'skill' }
     )
 
     # Simple (non-helper) aliases added for the categorized browser. Each must be

--- a/tests/gitconfig_helper.Tests.ps1
+++ b/tests/gitconfig_helper.Tests.ps1
@@ -110,6 +110,21 @@ import gitconfig_helper
             $scriptContent = Get-Content $helperScript -Raw
             $scriptContent | Should -Not -Match "def skill_push"
         }
+
+        It "defines list_skills and a skill dispatcher wired from __main__" {
+            $scriptContent = Get-Content $helperScript -Raw
+            $scriptContent | Should -Match 'def list_skills\('
+            $scriptContent | Should -Match 'def skill\('
+            $scriptContent | Should -Match 'function_name == "skill"'
+        }
+
+        It "list_skills reads a description and a last-updated date per skill" {
+            $scriptContent = Get-Content $helperScript -Raw
+            $scriptContent | Should -Match 'def _read_skill_description\('
+            $scriptContent | Should -Match 'def _skill_last_updated\('
+            # last-updated uses the skills repo git log, short date format
+            $scriptContent | Should -Match '--format=%cs'
+        }
     }
 
     Context "get_git_aliases Function" {

--- a/tests/gitconfig_helper.Tests.ps1
+++ b/tests/gitconfig_helper.Tests.ps1
@@ -429,6 +429,7 @@ import gitconfig_helper
             $script:src | Should -Match '"pr":\s*\("GitHub"'
             $script:src | Should -Match '"amend":\s*\("Commit"'
             $script:src | Should -Match '"s":\s*\("Inspect"'
+            $script:src | Should -Match '"skill":\s*\("Claude Skills"'
             $script:src | Should -Match '"skill-sync":\s*\("Claude Skills"'
             $script:src | Should -Match '"skill-publish":\s*\("Claude Skills"'
         }


### PR DESCRIPTION
Fixes #140

## Summary

Adds a `skill` subcommand-style git alias whose first form, `git skill list`, prints the installed Claude skills — the immediate subdirectories of `~/.claude/skills` that contain a `SKILL.md` (so `scripts/`, `.git/`, `.github/`, and loose files are excluded).

Implemented as a POSIX-`sh` dispatcher inside the alias, so it works on Windows, macOS, and Linux (git `!`-aliases always run in `sh`, even on Git for Windows) without OS branching. The dispatcher form leaves room for future `git skill <subcommand>` additions.

## Behavior

```
$ git skill list
clickup-to-servicedesk
compromised-password-remediation
git-policies
mintlify
mintlify-api
mintlify-docs

$ git skill            # or: git skill help
usage: git skill list

$ git skill bogus
git skill: unknown subcommand 'bogus' (try: list)   # exit 1
```

## Changes

- **`.gitconfig.template`** — new `skill` alias, grouped with the other `skill-*` aliases. Dispatches `list`; prints usage for no-arg/`help`; errors (exit 1) on unknown subcommands and when the skills dir is missing.
- **`gitconfig_helper.py`** — register `skill` in `ALIAS_METADATA` under "Claude Skills" so it shows up in the `git alias` browser.
- **`README.md`** / **`docs/CHANGELOG.md`** — document the new command.
- **`tests/gitconfig_helper.Tests.ps1`** — assert `skill` is categorized under "Claude Skills".

## Testing

- Ran the alias against a temp config (`GIT_CONFIG_GLOBAL` pointed at the template): `git skill list` lists 6 skills (exit 0); no-arg prints usage; unknown subcommand errors (exit 1).
- Full Pester suite green: **94/94** (`tests/gitconfig_helper.Tests.ps1`, `tests/GitconfigTemplate.Tests.ps1`).