### PR TITLE
fix: isolate cleanup tests in a throwaway repo

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `tests/gitconfig_helper.Tests.ps1` — the `cleanup Function` tests no longer run the
+  destructive `git cleanup` / `cleanup --force` / `cleanup -f` against the current working
+  directory. Run from a clone, that directory is the real repo, and `--force` deletes
+  local-only branches and moves `HEAD` to `main` — it silently deleted a freshly created
+  `feat/` branch during #141. The three tests now build a throwaway repo (with a wired bare
+  remote, a deleted-remote "gone" branch, and a local-only branch) in a temp dir, run inside
+  it, and restore the original location afterward — mirroring the `switch_to_main` /
+  `update_all_main` isolation. They also now assert the expected branches are deleted/kept
+  ([#142](https://github.com/J-MaFf/gitconfig/issues/142))
+
 - `scripts/mac version/initialize-local-config.sh` — always write `[gpg "ssh"]
   allowedSignersFile` when commit signing is enabled, not only when 1Password's
   `op-ssh-sign` is detected. The template ships a literal `signingkey` with

--- a/tests/gitconfig_helper.Tests.ps1
+++ b/tests/gitconfig_helper.Tests.ps1
@@ -64,23 +64,85 @@ import gitconfig_helper
     }
 
     Context "cleanup Function" {
+        # `cleanup` is DESTRUCTIVE: it switches HEAD to main and (with --force/-f)
+        # deletes local-only branches. Running it against the current directory
+        # would maul the developer's working clone when the suite is run from a
+        # checkout (this deleted a freshly created feat/ branch during PR #141).
+        # So each test runs inside a throwaway repo, mirroring the switch_to_main /
+        # update_all_main contexts below.
+        BeforeEach {
+            # Parent temp dir holds both the working repo and its bare "remote".
+            $script:cleanupParent = New-Item -ItemType Directory -Path "$env:TEMP\git_cleanup_$(Get-Random)" -Force
+            $repo = Join-Path $script:cleanupParent "repo"
+            $bare = Join-Path $script:cleanupParent "remote.git"
+            New-Item -ItemType Directory -Path $repo | Out-Null
+            Push-Location $repo
+
+            & git init 2>&1 | Out-Null
+            & git checkout -b main 2>&1 | Out-Null
+            & git config user.email "test@example.com" 2>&1 | Out-Null
+            & git config user.name "Test User" 2>&1 | Out-Null
+            & git config commit.gpgsign false 2>&1 | Out-Null
+            & git config init.defaultBranch main 2>&1 | Out-Null
+
+            # Initial commit on main, wired to a bare remote so fetch/pull succeed.
+            New-Item -Path "a.txt" -Value "a" -Force | Out-Null
+            & git add . 2>&1 | Out-Null
+            & git commit -m "init" 2>&1 | Out-Null
+            & git init --bare $bare 2>&1 | Out-Null
+            & git remote add origin $bare 2>&1 | Out-Null
+            & git push -u origin main 2>&1 | Out-Null
+
+            # A branch whose upstream was deleted ("[origin/...: gone]") -> cleanup
+            # auto-deletes it even without --force (the merged-branch case).
+            & git checkout -b feature-gone 2>&1 | Out-Null
+            & git push -u origin feature-gone 2>&1 | Out-Null
+            & git push origin --delete feature-gone 2>&1 | Out-Null
+
+            # A local-only branch (never pushed, no upstream) -> only --force deletes it.
+            & git checkout main 2>&1 | Out-Null
+            & git branch local-only 2>&1 | Out-Null
+
+            # Prune the stale remote-tracking ref so feature-gone reads as ": gone]".
+            & git fetch -p 2>&1 | Out-Null
+        }
+
+        AfterEach {
+            Pop-Location
+            Remove-Item -Path $script:cleanupParent -Recurse -Force -ErrorAction SilentlyContinue
+        }
+
         It "Should accept 'cleanup' function name without arguments" {
-            # Just verify it can be called - actual cleanup depends on git state
             $result = & python $script:helperScript cleanup 2>&1
             # Should complete execution (may return 0 or non-zero depending on git state)
             $result | Should -Not -BeNullOrEmpty
+
+            # Without --force: the gone-remote branch is deleted, the local-only branch survives.
+            $branches = & git branch --format='%(refname:short)'
+            $branches | Should -Not -Contain "feature-gone"
+            $branches | Should -Contain "local-only"
         }
 
         It "Should accept --force flag" {
-            $result = & python $helperScript cleanup --force 2>&1
+            $result = & python $script:helperScript cleanup --force 2>&1
             # Should complete execution with --force flag
             $result | Should -Not -BeNullOrEmpty
+
+            # With --force: both the gone-remote branch AND the local-only branch are deleted.
+            $branches = & git branch --format='%(refname:short)'
+            $branches | Should -Not -Contain "feature-gone"
+            $branches | Should -Not -Contain "local-only"
         }
 
         It "Should accept -f shorthand flag" {
-            $result = & python $helperScript cleanup -f 2>&1
+            $result = & python $script:helperScript cleanup -f 2>&1
             # Should complete execution with -f flag
             $result | Should -Not -BeNullOrEmpty
+
+            # -f behaves exactly like --force: both branches are deleted.
+            $branches = & git branch --format='%(refname:short)'
+            $branches | Should -Not -Contain "feature-gone"
+            $branches | Should -Not -Contain "local-only"
         }
 
         It "Should handle non-git directory gracefully" {


### PR DESCRIPTION
Fixes #142

## Problem

The `cleanup Function` tests in `tests/gitconfig_helper.Tests.ps1` invoked the real helper against the **current working directory**. Run from a clone, that directory is the actual `gitconfig` repo, and `git cleanup --force` / `-f` deletes local-only branches (no upstream) and switches `HEAD` to `main`. So running the suite from a working clone could **silently delete un-pushed feature branches and move HEAD** — it deleted a freshly created `feat/` branch during #141.

## Fix

Rewrote the three destructive cleanup tests (bare `cleanup`, `cleanup --force`, `cleanup -f`) to run inside an isolated temp repo, mirroring the existing `switch_to_main` / `update_all_main` contexts:

- `BeforeEach` builds a throwaway repo under a temp dir with a wired bare remote, a branch whose upstream was deleted (`[origin/...: gone]`), and a local-only branch; `Push-Location` into it for the test.
- `AfterEach` does `Pop-Location` and removes the temp tree (guaranteed restore).
- Each test now asserts the expected outcome:
  - no-force → the gone-remote branch is deleted, the local-only branch is **kept**
  - `--force` / `-f` → **both** branches are deleted

The "Should handle non-git directory gracefully" test is unchanged (already isolated). The suite can no longer run a destructive `cleanup --force` against the developer''s working repo.

## Testing

```powershell
Invoke-Pester -Path tests/gitconfig_helper.Tests.ps1 -Output Detailed
# Tests Passed: 62, Failed: 0
```

Captured local branches before and after the run: **identical**, and `HEAD` stayed on the feature branch — confirming no real branches are touched.

> Note: I deliberately did not run the full `tests/run-tests.ps1` from this session. In an interactive non-admin shell, its `Integration.Tests.ps1` runs `install.ps1 -Force` against the real `~/.gitconfig` (out of scope for this fix). The "94/94" full-suite count comes from a non-interactive context where those install/integration tests skip; this change adds/removes no `It` blocks, so that count is unaffected.