### PR TITLE
feat: adopt `git skill <subcommand>` style for the dashed skill-* aliases

### DIFF
--- a/.gitconfig.template
+++ b/.gitconfig.template
@@ -30,23 +30,16 @@
 	main = !"f() { for p in py python3 python; do command -v \"$p\" >/dev/null 2>&1 && \"$p\" -c '' >/dev/null 2>&1 && exec \"$p\" {{REPO_PATH}}/gitconfig_helper.py switch_to_main \"$@\"; done; echo 'No working Python found (tried py, python3, python)' >&2; return 1; }; f"
 	# Manage machine-specific git configuration
 	localconfig = !git config --file ~/.gitconfig.local
-	# Read-only skill subcommands operating on ~/.claude/skills (dispatches to the
-	# Python helper). `git skill list` shows each installed skill's name, a one-line
-	# description from its SKILL.md, and its last-updated date as a rich table.
+	# Manage ~/.claude/skills via subcommands (dispatches to the Python helper):
+	#   list      rich table of installed skills (name, description, last updated)
+	#   sync      sync the repo: status, pull --ff-only, status (flags unpublished work)
+	#   status    this machine's sync state (last background sync + local changes)
+	#   publish   publish new/edited skills via a PR (its main is branch-protected)
+	# `list` runs in Python; sync/status/publish delegate to the per-OS wrapper
+	# scripts in ~/.claude/skills/scripts (kept in the claude-skills repo so tweaks
+	# sync without touching this alias). `git skill` with no argument prints usage.
+	# Runs from any directory.
 	skill = !"f() { for p in py python3 python; do command -v \"$p\" >/dev/null 2>&1 && \"$p\" -c '' >/dev/null 2>&1 && exec \"$p\" {{REPO_PATH}}/gitconfig_helper.py skill \"$@\"; done; echo 'No working Python found (tried py, python3, python)' >&2; return 1; }; f"
-	# Sync the claude-skills repo (~/.claude/skills) on demand: show status, pull
-	# --ff-only, show status again, so unpublished local work is surfaced before and
-	# after. Dispatches by OS like skill-publish; runs from any directory. The wrapper
-	# lives in the claude-skills repo so future tweaks sync without touching this alias.
-	skill-sync = "!f() { case \"$(uname -s)\" in MINGW*|MSYS*|CYGWIN*) powershell -NoProfile -ExecutionPolicy Bypass -File \"$USERPROFILE\\.claude\\skills\\scripts\\skill-sync.ps1\" ;; *) bash \"$HOME/.claude/skills/scripts/skill-sync.sh\" ;; esac; }; f"
-	# Show this machine's claude-skills sync state on demand: last background sync
-	# (from ~/.claude/skills-sync.log) + any unpublished local changes. Read-only.
-	skill-sync-status = "!f() { case \"$(uname -s)\" in MINGW*|MSYS*|CYGWIN*) powershell -NoProfile -ExecutionPolicy Bypass -File \"$USERPROFILE\\.claude\\skills\\scripts\\skill-sync-status.ps1\" ;; *) bash \"$HOME/.claude/skills/scripts/skill-sync-status.sh\" ;; esac; }; f"
-	# Publish new/edited skills in the claude-skills repo (~/.claude/skills) via a
-	# PR (its main is branch-protected): branches off main, prompts for a commit
-	# message, makes a signed commit, opens a PR, and enables squash auto-merge.
-	# Dispatches by OS like selfupdate; runs from any directory.
-	skill-publish = "!f() { case \"$(uname -s)\" in MINGW*|MSYS*|CYGWIN*) powershell -NoProfile -ExecutionPolicy Bypass -File \"$USERPROFILE\\.claude\\skills\\scripts\\publish-skill.ps1\" ;; *) bash \"$HOME/.claude/skills/scripts/publish-skill.sh\" ;; esac; }; f"
 	# Pull the latest gitconfig repo and reinstall ~/.gitconfig from the template
 	# on demand. Dispatches by OS: Git-for-Windows reports MINGW/MSYS/CYGWIN.
 	selfupdate = "!f() { case \"$(uname -s)\" in MINGW*|MSYS*|CYGWIN*) powershell -NoProfile -File '{{REPO_PATH}}/scripts/windows version/Update-GitConfig.ps1' -RepoPath '{{REPO_PATH}}' ;; *) bash '{{REPO_PATH}}/scripts/shared/update-gitconfig.sh' '{{REPO_PATH}}' ;; esac; }; f"

--- a/README.md
+++ b/README.md
@@ -167,10 +167,11 @@ git selfupdate           # Pull this repo and reinstall ~/.gitconfig from the te
 **Claude Skills**
 
 ```bash
+git skill                # Print available subcommands (same as git skill help)
 git skill list           # Table of installed skills: name, description, last updated
-git skill-sync           # Sync ~/.claude/skills: status -> pull --ff-only -> status
-git skill-sync-status    # Show ~/.claude/skills state: last background sync + unpublished local changes
-git skill-publish        # Publish new/edited skills via a PR (prompts for a message, auto-merges)
+git skill sync           # Sync ~/.claude/skills: status -> pull --ff-only -> status
+git skill status         # Show ~/.claude/skills state: last background sync + unpublished local changes
+git skill publish        # Publish new/edited skills via a PR (prompts for a message, auto-merges)
 ```
 
 ### Setup Script Options (Windows)

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- `.gitconfig.template` / `gitconfig_helper.py` — adopted the `git <noun> <subcommand>`
+  style for the skill aliases. The dashed `git skill-sync`, `git skill-sync-status`, and
+  `git skill-publish` aliases are now the `git skill sync`, `git skill status`, and
+  `git skill publish` subcommands, joining the existing `git skill list`. `git skill` with
+  no argument (or `git skill help`) prints the available subcommands, and an unknown
+  subcommand errors (exit 1). The `skill` Python dispatcher handles `list` itself and
+  delegates `sync`/`status`/`publish` to the per-OS wrapper scripts in
+  `~/.claude/skills/scripts` (PowerShell on Windows, bash elsewhere), which stay in the
+  claude-skills repo so tweaks sync without touching this alias. `ALIAS_METADATA` now
+  carries a single `skill` entry describing all four subcommands, so the `git alias`
+  browser lists one discoverable "skill" row instead of three dashed ones
+  ([#144](https://github.com/J-MaFf/gitconfig/issues/144))
+
+### Removed
+
+- `.gitconfig.template` — the dashed `git skill-sync`, `git skill-sync-status`, and
+  `git skill-publish` aliases (replaced by the `git skill <subcommand>` forms above). This
+  is a breaking change: invocations or keybindings using the old hyphenated names must
+  switch to the space-separated subcommands ([#144](https://github.com/J-MaFf/gitconfig/issues/144))
+
 ### Added
 
 - `.gitconfig.template` — new `git skill list` alias that lists installed skills

--- a/gitconfig_helper.py
+++ b/gitconfig_helper.py
@@ -225,10 +225,7 @@ ALIAS_METADATA = {
     "localconfig": ("Maintenance", "Edit machine-specific git config (~/.gitconfig.local)"),
     "selfupdate": ("Maintenance", "Pull this repo and reinstall ~/.gitconfig from the template"),
     # Claude Skills
-    "skill": ("Claude Skills", "List installed skills in ~/.claude/skills with descriptions and last-updated dates (git skill list)"),
-    "skill-sync": ("Claude Skills", "Sync ~/.claude/skills: status, pull --ff-only, status (flags unpublished local work)"),
-    "skill-sync-status": ("Claude Skills", "Show ~/.claude/skills sync state: last background sync + unpublished local changes"),
-    "skill-publish": ("Claude Skills", "Publish new/edited skills (~/.claude/skills) via a PR with auto-merge"),
+    "skill": ("Claude Skills", "Manage ~/.claude/skills via subcommands: list, sync, status, publish (git skill <subcommand>)"),
 }
 
 
@@ -390,21 +387,72 @@ def list_skills():
     return 0
 
 
+# Subcommands that delegate to the per-OS wrapper scripts shipped in the
+# claude-skills repo (~/.claude/skills/scripts). Maps subcommand -> script base
+# name (the .ps1 and .sh share the base). Keeping these wrappers in that repo is
+# intentional so tweaks sync without touching this helper.
+SKILL_SCRIPTS = {
+    "sync": "skill-sync",
+    "status": "skill-sync-status",
+    "publish": "publish-skill",
+}
+
+# usage banner for `git skill` with no argument and `git skill help`.
+SKILL_USAGE = (
+    "usage: git skill <subcommand>\n"
+    "\n"
+    "  list      List installed skills (name, description, last updated)\n"
+    "  sync      Sync ~/.claude/skills: status, pull --ff-only, status\n"
+    "  status    Show this machine's ~/.claude/skills sync state\n"
+    "  publish   Publish new/edited skills via a PR (auto-merge)"
+)
+
+
+def _run_skill_script(base):
+    """Run a claude-skills wrapper script (~/.claude/skills/scripts/<base>.{ps1,sh}).
+
+    Picks the per-OS variant: PowerShell on Windows, bash elsewhere. Returns the
+    script's exit code, or 1 if the expected script file is missing.
+    """
+    scripts_dir = os.path.join(os.path.expanduser("~"), ".claude", "skills", "scripts")
+    if sys.platform == "win32":
+        script = os.path.join(scripts_dir, base + ".ps1")
+        cmd = ["powershell", "-NoProfile", "-ExecutionPolicy", "Bypass", "-File", script]
+    else:
+        script = os.path.join(scripts_dir, base + ".sh")
+        cmd = ["bash", script]
+    if not os.path.isfile(script):
+        Console(stderr=True).print(
+            f"[red]git skill: wrapper script not found: {script}[/red]"
+        )
+        return 1
+    return subprocess.run(cmd).returncode
+
+
 def skill(args):
     """Dispatch a `git skill <subcommand>` invocation.
 
     Subcommands:
-      list   List installed skills in ~/.claude/skills (name, description,
-             last-updated date) as a table.
+      list      List installed skills in ~/.claude/skills (name, description,
+                last-updated date) as a table.
+      sync      Sync ~/.claude/skills: status, pull --ff-only, status.
+      status    Show this machine's ~/.claude/skills sync state.
+      publish   Publish new/edited skills via a PR with auto-merge.
+
+    `list` is handled here in Python; sync/status/publish delegate to the per-OS
+    wrapper scripts shipped in the claude-skills repo (see SKILL_SCRIPTS).
     """
     sub = args[0] if args else ""
     if sub == "list":
         return list_skills()
+    if sub in SKILL_SCRIPTS:
+        return _run_skill_script(SKILL_SCRIPTS[sub])
     if sub in ("", "help", "-h", "--help"):
-        Console().print("usage: git skill list")
+        Console().print(SKILL_USAGE)
         return 0
     Console(stderr=True).print(
-        f"[red]git skill: unknown subcommand '{sub}' (try: list)[/red]"
+        f"[red]git skill: unknown subcommand '{sub}' "
+        f"(try: list, sync, status, publish)[/red]"
     )
     return 1
 

--- a/tests/gitconfig_helper.Tests.ps1
+++ b/tests/gitconfig_helper.Tests.ps1
@@ -160,9 +160,16 @@ import gitconfig_helper
     }
 
     Context "skill aliases" {
-        It "skill-publish should be described in alias_descriptions" {
+        It "no longer describes the removed dashed skill aliases in ALIAS_METADATA" {
+            # #144 migrated skill-sync/skill-sync-status/skill-publish to the
+            # `git skill <subcommand>` form, so the dashed names are gone from
+            # ALIAS_METADATA (only the single `skill` row remains). Match on the
+            # metadata-tuple form so the SKILL_SCRIPTS values (e.g. "skill-sync")
+            # don't trip this assertion.
             $scriptContent = Get-Content $helperScript -Raw
-            $scriptContent | Should -Match '"skill-publish"'
+            $scriptContent | Should -Not -Match '"skill-sync":\s*\('
+            $scriptContent | Should -Not -Match '"skill-sync-status":\s*\('
+            $scriptContent | Should -Not -Match '"skill-publish":\s*\('
         }
 
         It "should no longer define the obsolete skill_push helper" {
@@ -178,6 +185,17 @@ import gitconfig_helper
             $scriptContent | Should -Match 'def list_skills\('
             $scriptContent | Should -Match 'def skill\('
             $scriptContent | Should -Match 'function_name == "skill"'
+        }
+
+        It "skill dispatcher routes sync/status/publish to per-OS wrapper scripts" {
+            # list runs in Python; sync/status/publish delegate to the claude-skills
+            # wrapper scripts (.ps1 on Windows, .sh elsewhere) via SKILL_SCRIPTS.
+            $scriptContent = Get-Content $helperScript -Raw
+            $scriptContent | Should -Match 'SKILL_SCRIPTS'
+            $scriptContent | Should -Match '"sync":\s*"skill-sync"'
+            $scriptContent | Should -Match '"status":\s*"skill-sync-status"'
+            $scriptContent | Should -Match '"publish":\s*"publish-skill"'
+            $scriptContent | Should -Match 'def _run_skill_script\('
         }
 
         It "list_skills reads a description and a last-updated date per skill" {
@@ -507,8 +525,6 @@ import gitconfig_helper
             $script:src | Should -Match '"amend":\s*\("Commit"'
             $script:src | Should -Match '"s":\s*\("Inspect"'
             $script:src | Should -Match '"skill":\s*\("Claude Skills"'
-            $script:src | Should -Match '"skill-sync":\s*\("Claude Skills"'
-            $script:src | Should -Match '"skill-publish":\s*\("Claude Skills"'
         }
 
         It "get_git_aliases returns (name, description, category) tuples" {


### PR DESCRIPTION
Fixes #144

## Summary

Migrates the hyphenated `skill-*` aliases to the `git <noun> <subcommand>` style, joining the existing `git skill list` (added in #141):

| Old | New |
|-----|-----|
| `git skill-sync` | `git skill sync` |
| `git skill-sync-status` | `git skill status` |
| `git skill-publish` | `git skill publish` |

The `skill` dispatcher now exposes: `list`, `sync`, `status`, `publish`.

## Design decisions (the issue's open questions)

1. **Backward compatibility — clean break.** The dashed aliases are removed outright (personal repo). The CHANGELOG documents this as a breaking change.
2. **Dispatcher — Python dispatcher shells out.** The `skill` alias stays trivial (the standard `py`/`python3`/`python` resolver → `gitconfig_helper.py skill`). Python handles `list` itself (the `rich` table) and routes `sync`/`status`/`publish` to the per-OS wrapper scripts in `~/.claude/skills/scripts` via `_run_skill_script` (PowerShell on Windows, bash elsewhere). The wrapper scripts stay in the claude-skills repo, so tweaks still sync without touching this alias. One central place for help/usage/unknown-subcommand handling.
3. **Surfacing subcommands.** `ALIAS_METADATA` collapses the four rows into a single `skill` entry that names all subcommands, so the `git alias` browser shows one discoverable noun. `git skill` (and `git skill help`) prints a usage banner listing every subcommand.
4. **`skill-sync-status` → `git skill status`** (the issue's primary proposal).

## Behavior

```
$ git skill            # or: git skill help
usage: git skill <subcommand>

  list      List installed skills (name, description, last updated)
  sync      Sync ~/.claude/skills: status, pull --ff-only, status
  status    Show this machine's ~/.claude/skills sync state
  publish   Publish new/edited skills via a PR (auto-merge)

$ git skill bogus
git skill: unknown subcommand 'bogus' (try: list, sync, status, publish)   # exit 1
```

## Changes

- **`.gitconfig.template`** — remove the three dashed aliases; the single `skill` alias comment now documents all four subcommands.
- **`gitconfig_helper.py`** — extend `skill()` with `SKILL_SCRIPTS`, `SKILL_USAGE`, and `_run_skill_script`; collapse the four `ALIAS_METADATA` rows into one.
- **`README.md`** / **`docs/CHANGELOG.md`** — document the new forms and the breaking removal.
- **`tests/gitconfig_helper.Tests.ps1`** — assert the dashed metadata rows are gone and the dispatcher maps `sync`/`status`/`publish` to the wrapper scripts.

## Testing

- Manual (Windows): `git skill` (usage), `git skill help`, `git skill list`, `git skill status` (end-to-end through `skill-sync-status.ps1`), and `git skill bogus` (exit 1) — all behave as expected.
- Pester: all skill-related unit tests pass. Three pre-existing failures in `switch_to_main`/`update_all_main` are unrelated — this machine's `init.defaultBranch = master`, so those tests' throwaway repos default to `master` while the code targets `main` (untouched by this PR).

> Note: committed **unsigned** with the author's explicit one-time approval — this machine has no `user.signingkey`/global `~/.gitconfig` and the 1Password SSH agent socket is absent, so `git commit -S` couldn't sign.