### PR TITLE
chore: ignore Pester coverage.xml output in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,10 @@
 test_output.txt
 docs/update-gitconfig.log
 
+# Pester generated reports (config/pester.config.ps1 enables code coverage)
+coverage.xml
+testResults.xml
+
 # Claude Code local session data
 .claude/
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- `.gitignore` — ignore Pester's generated `coverage.xml` code-coverage report (emitted at
+  the repo root when `config/pester.config.ps1` runs with `CodeCoverage.Enabled = $true`),
+  plus `testResults.xml` defensively (Pester's default test-result filename, not currently
+  emitted since `TestResult` output is disabled). Keeps generated test artifacts out of
+  `git status` ([#146](https://github.com/J-MaFf/gitconfig/issues/146))
+
 ### Changed
 
 - `.gitconfig.template` / `gitconfig_helper.py` — adopted the `git <noun> <subcommand>`


### PR DESCRIPTION
Fixes #146

## Problem

Running the Pester suite with the project config (`config/pester.config.ps1`) leaves an untracked `coverage.xml` at the repo root. That config sets `CodeCoverage.Enabled = $true` and does not override `CodeCoverage.OutputPath`, so Pester 5 writes its default `coverage.xml` (JaCoCo) into the working directory. The file is a generated artifact and was not in `.gitignore`, so it showed up as untracked and could be committed accidentally.

## Changes

- `.gitignore` — add a "Pester generated reports" block ignoring `coverage.xml` and `testResults.xml`.
- `docs/CHANGELOG.md` — add an `Unreleased > Fixed` entry.

## On `testResults.xml`

I checked whether Pester also emits `testResults.xml`. It does **not** today: no invocation in this repo sets `TestResult.Enabled = $true` (neither `config/pester.config.ps1` nor `tests/run-tests.ps1`), and Pester 5 disables test-result output by default. It is added defensively — it's Pester's default test-result filename and would appear the moment anyone enables that output.

## Testing

No runtime behavior changes — `.gitignore` and docs only. Verified that `config/pester.config.ps1` enables code coverage with the default output path and that no `TestResult` output is enabled anywhere in the repo.