### PR TITLE
fix: validate generated file in Initialize-LocalConfig verification

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `scripts/windows version/Initialize-LocalConfig.ps1` — fixed a spurious `[WARN] Git may
+  have issues reading the configuration` printed by `install.ps1`. The verification step
+  used `git config --local --list`, which reads the *repository* `.git/config` (unrelated to
+  the generated `~/.gitconfig.local`) and errors with exit 128 when the current directory
+  isn't a git repo — and `install.ps1` runs from the home directory. It now validates the
+  generated file directly with `git config --file $localConfigPath --list` (scope- and
+  CWD-independent), matching `Initialize-GitConfig.ps1` and `scripts/shared/functions.sh`.
+  Added Pester coverage asserting the `[OK]` result (and no WARN) when run outside a repo
+  ([#148](https://github.com/J-MaFf/gitconfig/issues/148))
+
 - `.gitignore` — ignore Pester's generated `coverage.xml` code-coverage report (emitted at
   the repo root when `config/pester.config.ps1` runs with `CodeCoverage.Enabled = $true`),
   plus `testResults.xml` defensively (Pester's default test-result filename, not currently

--- a/scripts/windows version/Initialize-LocalConfig.ps1
+++ b/scripts/windows version/Initialize-LocalConfig.ps1
@@ -172,9 +172,13 @@ try {
     Write-Host "  3. Save and reload git" -ForegroundColor Gray
     Write-Host ""
 
-    # Verify git can read the config
+    # Verify git can read the config. Validate the generated file directly with
+    # --file (scope- and CWD-independent) rather than --local, which reads the
+    # repo's .git/config and errors (exit 128) when the current directory isn't a
+    # git repo. install.ps1 runs from the home directory, so --local produced a
+    # spurious [WARN]. Mirrors Initialize-GitConfig.ps1 and shared/functions.sh.
     Write-Host "Verifying git configuration..." -ForegroundColor Cyan
-    & git config --local --list 2>&1 | Out-Null
+    & git config --file $localConfigPath --list 2>&1 | Out-Null
     if ($LASTEXITCODE -eq 0) {
         Write-Host "[OK] Git configuration verified!" -ForegroundColor Green
     }

--- a/tests/Initialize-LocalConfig.Tests.ps1
+++ b/tests/Initialize-LocalConfig.Tests.ps1
@@ -87,4 +87,53 @@ Describe "Initialize-LocalConfig.ps1" {
             $content | Should -Match 'sandbox@example.com'
         }
     }
+
+    Context "config verification" {
+        BeforeEach {
+            # Same sandbox isolation as above; the sandbox dir is deliberately NOT
+            # a git repo (it lives under TestDrive), which is the condition that
+            # exposed the verification-scope bug.
+            $script:sandbox = Join-Path $TestDrive ([guid]::NewGuid().ToString("N"))
+            New-Item -ItemType Directory -Path $script:sandbox -Force | Out-Null
+
+            $script:savedUserProfile = $env:USERPROFILE
+            $script:savedHome = $env:HOME
+            $script:savedGlobal = $env:GIT_CONFIG_GLOBAL
+            $script:savedSystem = $env:GIT_CONFIG_SYSTEM
+
+            $env:USERPROFILE = $script:sandbox
+            $env:HOME = $script:sandbox
+            $env:GIT_CONFIG_GLOBAL = Join-Path $script:sandbox ".gitconfig"
+            $env:GIT_CONFIG_SYSTEM = Join-Path $script:sandbox "no-system-config"
+
+            git config --global user.email "sandbox@example.com" 2>&1 | Out-Null
+            git config --global user.signingkey "ssh-ed25519 AAAASANDBOXKEY test-comment" 2>&1 | Out-Null
+        }
+
+        AfterEach {
+            $env:USERPROFILE = $script:savedUserProfile
+            $env:HOME = $script:savedHome
+            $env:GIT_CONFIG_GLOBAL = $script:savedGlobal
+            $env:GIT_CONFIG_SYSTEM = $script:savedSystem
+        }
+
+        It "Should verify the generated config (not WARN) when run outside a git repo" {
+            # Regression guard for #148: the script must validate the file it wrote
+            # (git config --file ...), not the repo config (git config --local ...),
+            # which errors when the current directory isn't a git repo. The sandbox
+            # CWD is not a repo, so the old --local check printed a spurious WARN.
+            # Capture all streams (*>&1) so Write-Host's information-stream output
+            # lands in $out; 2>&1 alone would miss it.
+            Push-Location $script:sandbox
+            try { $out = & $script:scriptPath -Force *>&1 } finally { Pop-Location }
+            $text = $out | Out-String
+
+            $text | Should -Match '\[OK\] Git configuration verified!'
+            $text | Should -Not -Match 'Git may have issues reading the configuration'
+        }
+
+        It "Should not use the CWD-dependent 'git config --local' check" {
+            (Get-Content $script:scriptPath -Raw) | Should -Not -Match 'git config --local --list'
+        }
+    }
 }


### PR DESCRIPTION
Fixes #148

## Summary

`scripts/windows version/Initialize-LocalConfig.ps1` printed a spurious `[WARN] Git may have issues reading the configuration` during `install.ps1`, even though the generated `~/.gitconfig.local` is valid and git reads it fine.

## Root cause

The verification step used the wrong config scope:

```powershell
& git config --local --list 2>&1 | Out-Null   # reads the REPO's .git/config
```

`git config --local` reads the repository `.git/config` — unrelated to the global-include file the script just wrote — and **errors with exit 128** (`fatal: --local can only be used inside a git repository`) when the current directory isn't a git repo. `install.ps1` runs from the home directory, so the check always tripped the WARN there; run from inside a repo it passed. The result was CWD-dependent.

## Fix

Validate the generated file directly (scope- and CWD-independent), matching the patterns already used elsewhere in the repo:

```powershell
& git config --file $localConfigPath --list 2>&1 | Out-Null
```

- `scripts/windows version/Initialize-GitConfig.ps1:113` already uses `git config --file $outputPath --list`
- `scripts/shared/functions.sh:59` already uses `git config --file "$output_path" --list`

This was the only one of the three local/global config generators still using the buggy `--local` scope.

## Changes

- **`scripts/windows version/Initialize-LocalConfig.ps1`** — swap `--local` for `--file $localConfigPath` in the verification step (+ explanatory comment).
- **`tests/Initialize-LocalConfig.Tests.ps1`** — new `config verification` context: asserts the `[OK] Git configuration verified!` line (and absence of the WARN) when the script runs from a non-repo sandbox, and that the source no longer uses `git config --local --list`. The existing tests already ran from a non-repo sandbox but piped output to `Out-Null`, so they never caught this.
- **`docs/CHANGELOG.md`** — Fixed entry.

## Testing

```
Initialize-LocalConfig.Tests.ps1 — 7/7 pass (5 existing + 2 new)
```

Also reproduced the original bug directly: `git config --local --list` from the home dir exits 128 (`fatal: --local can only be used inside a git repository`); `git config --file <localpath> --list` exits 0.

Not a functional problem (the config was always correct) — purely a misleading install message.