### PR TITLE
docs: clarify git skill sync is pull-only, not two-way

### DIFF
--- a/.gitconfig.template
+++ b/.gitconfig.template
@@ -32,7 +32,7 @@
 	localconfig = !git config --file ~/.gitconfig.local
 	# Manage ~/.claude/skills via subcommands (dispatches to the Python helper):
 	#   list      rich table of installed skills (name, description, last updated)
-	#   sync      sync the repo: status, pull --ff-only, status (flags unpublished work)
+	#   sync      pull-only refresh: pull --ff-only (flags unpublished work, never publishes)
 	#   status    this machine's sync state (last background sync + local changes)
 	#   publish   publish new/edited skills via a PR (its main is branch-protected)
 	# `list` runs in Python; sync/status/publish delegate to the per-OS wrapper

--- a/gitconfig_helper.py
+++ b/gitconfig_helper.py
@@ -402,7 +402,7 @@ SKILL_USAGE = (
     "usage: git skill <subcommand>\n"
     "\n"
     "  list      List installed skills (name, description, last updated)\n"
-    "  sync      Sync ~/.claude/skills: status, pull --ff-only, status\n"
+    "  sync      Pull ~/.claude/skills (--ff-only); never publishes local work\n"
     "  status    Show this machine's ~/.claude/skills sync state\n"
     "  publish   Publish new/edited skills via a PR (auto-merge)"
 )
@@ -435,7 +435,8 @@ def skill(args):
     Subcommands:
       list      List installed skills in ~/.claude/skills (name, description,
                 last-updated date) as a table.
-      sync      Sync ~/.claude/skills: status, pull --ff-only, status.
+      sync      Pull ~/.claude/skills (--ff-only); flags unpublished local
+                work but never publishes it (publish with `publish`).
       status    Show this machine's ~/.claude/skills sync state.
       publish   Publish new/edited skills via a PR with auto-merge.
 


### PR DESCRIPTION
Fixes #150

`git skill sync`'s one-line description led with **"Sync ~/.claude/skills"**, which reads as a two-way operation (push + pull). The subcommand is **pull-only**: it fast-forwards `~/.claude/skills` from the remote and *flags* unpublished local work — it never publishes it (that's `git skill publish`).

## Changes
- **`SKILL_USAGE` banner** — `Pull ~/.claude/skills (--ff-only); never publishes local work` (kept to one line so it doesn't wrap in an 80-col terminal)
- **`skill()` docstring** — same clarification, pointing publishing at the `publish` subcommand
- **`.gitconfig.template` comment** — `pull-only refresh: pull --ff-only (flags unpublished work, never publishes)`

## Before / after (`git skill`)
```
- sync      Sync ~/.claude/skills: status, pull --ff-only, status
+ sync      Pull ~/.claude/skills (--ff-only); never publishes local work
```

## Validation
- `py -m py_compile gitconfig_helper.py` passes
- `git skill` renders the new banner on one line (no test pins the string)