### PR TITLE
feat: declare Python deps in pyproject.toml; consolidate install logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,6 +204,9 @@ python -m pip install rich textual
 
 `rich` is required; `textual` is optional and only powers the interactive
 `git alias` browser. Without it, `git alias` shows the static grouped table.
+These are declared in [`pyproject.toml`](pyproject.toml) (`rich` required; `textual`
+under the optional `tui` extra); the setup/update scripts read it and install them
+for you, so the manual `pip install` above is only needed as a fallback.
 
 **`git alias` shows a static table instead of the interactive browser:** install
 `textual` (`pip install textual`) and run `git alias` directly in a terminal —

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`pyproject.toml` dependency manifest** — the helper's Python deps are now declared in one
+  place: `rich` (required) under `[project.dependencies]` and `textual` (optional) under the
+  `[project.optional-dependencies].tui` extra. Declaration only — the repo is scripts, not a
+  pip-installable package. A dependency-free `scripts/shared/deps.py` reads it (tomllib with a
+  regex fallback for Python < 3.11) ([#153](https://github.com/J-MaFf/gitconfig/issues/153))
+
+### Changed
+
+- **Consolidated the duplicated Python-dependency install logic** behind one routine per platform
+  family that reads the manifest: `install_python_deps` in `scripts/shared/functions.sh` (bash, for
+  the mac/linux installers + the login auto-update) and `Install-PythonDeps` in the new
+  `scripts/windows version/Functions.ps1` (PowerShell, for `install.ps1` + `Update-GitConfig.ps1`).
+  Replaced five near-identical pip blocks with calls. Behaviour is unchanged — idempotent,
+  `py`→`python3`→`python` resolution, `--break-system-packages` fallback, optional-dep failure stays
+  a warning. Pester tests retargeted to the new structure
+  ([#153](https://github.com/J-MaFf/gitconfig/issues/153))
+
 ### Fixed
 
 - `scripts/windows version/Initialize-LocalConfig.ps1` — fixed a spurious `[WARN] Git may

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   place: `rich` (required) under `[project.dependencies]` and `textual` (optional) under the
   `[project.optional-dependencies].tui` extra. Declaration only — the repo is scripts, not a
   pip-installable package. A dependency-free `scripts/shared/deps.py` reads it (tomllib with a
-  regex fallback for Python < 3.11) ([#153](https://github.com/J-MaFf/gitconfig/issues/153))
+  regex fallback for Python < 3.11) ([#154](https://github.com/J-MaFf/gitconfig/pull/154), closes [#153](https://github.com/J-MaFf/gitconfig/issues/153))
 
 ### Changed
 
@@ -24,7 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Replaced five near-identical pip blocks with calls. Behaviour is unchanged — idempotent,
   `py`→`python3`→`python` resolution, `--break-system-packages` fallback, optional-dep failure stays
   a warning. Pester tests retargeted to the new structure
-  ([#153](https://github.com/J-MaFf/gitconfig/issues/153))
+  ([#154](https://github.com/J-MaFf/gitconfig/pull/154))
 
 ### Fixed
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,23 @@
+# Dependency manifest for the gitconfig helper tooling.
+#
+# DECLARATION ONLY. This repo is a collection of scripts, not a pip-installable
+# package — there is intentionally no [build-system] and you do not `pip install .`.
+# The setup/update scripts read these names via scripts/shared/deps.py and install
+# them directly (degrading gracefully if the optional group is unavailable).
+[project]
+name = "gitconfig-tooling"
+version = "0.0.0"
+description = "Helper tooling for the gitconfig repo (git-alias browser, maintenance)."
+requires-python = ">=3.8"
+
+# Required: gitconfig_helper.py renders its alias/skill tables with rich.
+dependencies = [
+    "rich>=13",
+]
+
+[project.optional-dependencies]
+# Optional: the interactive `git alias` browser (Ctrl-G) uses textual. Without it
+# the helper falls back to a static table, so a missing textual is never fatal.
+tui = [
+    "textual>=0.50",
+]

--- a/scripts/linux version/install.sh
+++ b/scripts/linux version/install.sh
@@ -153,27 +153,13 @@ if [ "$NO_CRON" = false ]; then
     echo ""
 fi
 
-# STEP 6: Install Python dependencies
+# STEP 6: Install Python dependencies (rich required; textual optional, for the
+# interactive 'git alias' browser). Declared in pyproject.toml and installed by
+# the shared install_python_deps routine (single source of truth across mac/linux
+# install + the login auto-update).
 echo "[STEP 6] Installing Python dependencies..."
 echo "-----"
-# 'rich' is required for the helper's tables; 'textual' is optional and only
-# powers the interactive 'git alias' browser (the helper falls back to a static
-# table without it), so a failed textual install is a warning, not an error.
-if command -v pip3 &>/dev/null; then
-    if pip3 show rich &>/dev/null 2>&1 && pip3 show textual &>/dev/null 2>&1; then
-        echo "[OK] Python 'rich' and 'textual' already installed"
-    elif pip3 install rich textual --quiet 2>/dev/null; then
-        echo "[OK] Installed Python 'rich' and 'textual'"
-    elif pip3 install rich textual --quiet --break-system-packages 2>/dev/null; then
-        echo "[OK] Installed Python 'rich' and 'textual' (--break-system-packages)"
-    elif pip3 install rich --quiet 2>/dev/null || pip3 install rich --quiet --break-system-packages 2>/dev/null; then
-        echo "[OK] Installed Python 'rich' (textual unavailable; 'git alias' uses the static table)"
-    else
-        echo "[WARN] Could not install 'rich' — run manually: pip3 install rich textual"
-    fi
-else
-    echo "[WARN] pip3 not found — install Python 3: sudo apt install python3-pip"
-fi
+install_python_deps "$REPO_ROOT"
 echo ""
 
 # STEP 6b: Enable the interactive git-alias browser keybinding (Ctrl-G)

--- a/scripts/mac version/install.sh
+++ b/scripts/mac version/install.sh
@@ -193,27 +193,13 @@ PLIST
     echo ""
 fi
 
-# STEP 6: Install Python dependencies
+# STEP 6: Install Python dependencies (rich required; textual optional, for the
+# interactive 'git alias' browser). Declared in pyproject.toml and installed by
+# the shared install_python_deps routine (single source of truth across mac/linux
+# install + the login auto-update).
 echo "[STEP 6] Installing Python dependencies..."
 echo "-----"
-# 'rich' is required for the helper's tables; 'textual' is optional and only
-# powers the interactive 'git alias' browser (the helper falls back to a static
-# table without it), so a failed textual install is a warning, not an error.
-if command -v pip3 &>/dev/null; then
-    if pip3 show rich &>/dev/null 2>&1 && pip3 show textual &>/dev/null 2>&1; then
-        echo "[OK] Python 'rich' and 'textual' already installed"
-    elif pip3 install rich textual --quiet 2>/dev/null; then
-        echo "[OK] Installed Python 'rich' and 'textual'"
-    elif pip3 install rich textual --quiet --break-system-packages 2>/dev/null; then
-        echo "[OK] Installed Python 'rich' and 'textual' (--break-system-packages)"
-    elif pip3 install rich --quiet 2>/dev/null || pip3 install rich --quiet --break-system-packages 2>/dev/null; then
-        echo "[OK] Installed Python 'rich' (textual unavailable; 'git alias' uses the static table)"
-    else
-        echo "[WARN] Could not install 'rich' — run manually: pip3 install rich textual"
-    fi
-else
-    echo "[WARN] pip3 not found — install Python 3 via Homebrew: brew install python"
-fi
+install_python_deps "$REPO_ROOT"
 echo ""
 
 # STEP 6b: Enable the interactive git-alias browser keybinding (Ctrl-G)

--- a/scripts/shared/deps.py
+++ b/scripts/shared/deps.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python3
+"""Print the project's declared Python dependencies from pyproject.toml.
+
+Usage: deps.py {required|optional|all}
+  required  core deps ([project] dependencies)        -> one spec per line
+  optional  the 'tui' optional-dependencies group     -> one spec per line
+  all       both                                       -> one spec per line
+
+No third-party imports: this runs to *bootstrap* installing 'rich'/'textual', so
+it must work on a bare interpreter. Uses tomllib (Python 3.11+) when available,
+otherwise a small regex fallback that handles this repo's simple manifest layout.
+One spec per line so callers can read them into an array without word-splitting
+on version operators or PEP 508 spaces.
+"""
+import os
+import re
+import sys
+
+_HERE = os.path.dirname(os.path.abspath(__file__))
+# pyproject.toml lives at the repo root: scripts/shared/ -> ../../
+PYPROJECT = os.path.normpath(os.path.join(_HERE, "..", "..", "pyproject.toml"))
+
+
+def _load_required_optional():
+    """Return (required_list, optional_tui_list) of requirement strings."""
+    try:
+        import tomllib  # Python 3.11+
+        with open(PYPROJECT, "rb") as fh:
+            data = tomllib.load(fh)
+        project = data.get("project", {})
+        required = list(project.get("dependencies", []))
+        optional = list(project.get("optional-dependencies", {}).get("tui", []))
+        return required, optional
+    except ModuleNotFoundError:
+        pass  # fall through to the regex fallback
+
+    with open(PYPROJECT, encoding="utf-8") as fh:
+        text = fh.read()
+
+    def _array(pattern):
+        match = re.search(pattern, text, re.DOTALL)
+        if not match:
+            return []
+        return re.findall(r"""["']([^"']+)["']""", match.group(1))
+
+    # `^\s*dependencies\s*=` matches the core array but not the
+    # `[project.optional-dependencies]` table header or a `tui =` sub-key.
+    required = _array(r"(?m)^\s*dependencies\s*=\s*\[(.*?)\]")
+    optional = _array(r"(?ms)^\s*tui\s*=\s*\[(.*?)\]")
+    return required, optional
+
+
+def main():
+    which = sys.argv[1] if len(sys.argv) > 1 else "all"
+    required, optional = _load_required_optional()
+    if which == "required":
+        out = required
+    elif which == "optional":
+        out = optional
+    else:
+        out = required + optional
+    for spec in out:
+        print(spec)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/shared/functions.sh
+++ b/scripts/shared/functions.sh
@@ -264,3 +264,89 @@ disable_git_alias_widget() {
         echo "[OK] Disabled git-alias keybinding in $rc"
     done
 }
+
+# pip install helper: quiet, normal then a --break-system-packages retry for PEP
+# 668 "externally-managed" environments (Homebrew/Debian system Python).
+# Usage: _pip_install PYTHON_BIN PKG...
+_pip_install() {
+    local py="$1"; shift
+    "$py" -m pip install --quiet "$@" >/dev/null 2>&1 \
+        || "$py" -m pip install --quiet --break-system-packages "$@" >/dev/null 2>&1
+}
+
+# Install the Python dependencies declared in pyproject.toml (read via
+# scripts/shared/deps.py): the required deps (rich) plus the optional 'tui' group
+# (textual). Single source of truth for what gets installed — the mac/linux
+# installers and the login auto-update all call this instead of duplicating pip
+# logic. Idempotent (only installs what is not already importable), resolves the
+# interpreter py -> python3 -> python like the git aliases, and treats a failed
+# *optional* install as a warning (the helper falls back to a static table).
+# Every fallible step is guarded so this is safe under `set -e`.
+# Usage: install_python_deps REPO_ROOT
+install_python_deps() {
+    local repo_root="$1"
+    local deps_py="$repo_root/scripts/shared/deps.py"
+    local py="" p spec name
+    local -a required=() optional=() need_required=() need_optional=()
+
+    for p in py python3 python; do
+        if command -v "$p" >/dev/null 2>&1 && "$p" -c '' >/dev/null 2>&1; then
+            py="$p"; break
+        fi
+    done
+    if [ -z "$py" ]; then
+        echo "[WARN] No Python interpreter found; skipping rich/textual (install Python 3, then re-run)"
+        return 0
+    fi
+    if [ ! -f "$deps_py" ]; then
+        echo "[WARN] $deps_py not found; skipping Python dependency install"
+        return 0
+    fi
+    if ! "$py" -m pip --version >/dev/null 2>&1; then
+        echo "[WARN] pip unavailable for $py; install rich (and optionally textual) manually"
+        return 0
+    fi
+
+    # Declared specs, one per line, into arrays (avoids word-splitting on '>=').
+    while IFS= read -r spec; do [ -n "$spec" ] && required+=("$spec"); done < <("$py" "$deps_py" required)
+    while IFS= read -r spec; do [ -n "$spec" ] && optional+=("$spec"); done < <("$py" "$deps_py" optional)
+
+    # Only install what is not already importable (import name = spec minus any
+    # version operator: "rich>=13" -> "rich").
+    for spec in "${required[@]}"; do
+        name="${spec%%[<>=!~ ]*}"
+        "$py" -c "import ${name}" >/dev/null 2>&1 || need_required+=("$spec")
+    done
+    for spec in "${optional[@]}"; do
+        name="${spec%%[<>=!~ ]*}"
+        "$py" -c "import ${name}" >/dev/null 2>&1 || need_optional+=("$spec")
+    done
+
+    if [ "${#need_required[@]}" -eq 0 ] && [ "${#need_optional[@]}" -eq 0 ]; then
+        echo "[OK] Python dependencies already present (rich + textual)"
+        return 0
+    fi
+
+    if [ "${#need_required[@]}" -gt 0 ]; then
+        # Try required + optional together; if that fails, make sure the required
+        # land even when an optional dep is unavailable on this platform.
+        if [ "${#need_optional[@]}" -gt 0 ] && _pip_install "$py" "${need_required[@]}" "${need_optional[@]}"; then
+            echo "[OK] Installed Python deps: ${need_required[*]} ${need_optional[*]}"
+        elif _pip_install "$py" "${need_required[@]}"; then
+            if [ "${#need_optional[@]}" -gt 0 ]; then
+                echo "[OK] Installed required Python deps: ${need_required[*]} (optional unavailable; 'git alias' uses the static table)"
+            else
+                echo "[OK] Installed required Python deps: ${need_required[*]}"
+            fi
+        else
+            echo "[WARN] Could not install required Python deps (${need_required[*]}) — run: $py -m pip install ${need_required[*]}"
+        fi
+    elif [ "${#need_optional[@]}" -gt 0 ]; then
+        if _pip_install "$py" "${need_optional[@]}"; then
+            echo "[OK] Installed optional Python deps: ${need_optional[*]}"
+        else
+            echo "[WARN] Optional Python deps unavailable (${need_optional[*]}); 'git alias' uses the static table"
+        fi
+    fi
+    return 0
+}

--- a/scripts/shared/update-gitconfig.sh
+++ b/scripts/shared/update-gitconfig.sh
@@ -61,30 +61,12 @@ mkdir -p "$(dirname "$LOG_FILE")"
         log_message "ERROR: could not converge ~/.gitconfig from template"
     fi
 
-    # Ensure the optional 'textual' dependency (for the interactive `git alias`
-    # browser) is present. Best-effort and idempotent: resolves the interpreter
-    # py -> python3 -> python like the aliases, only installs when textual is
-    # missing, and never fails the update if the install does not succeed.
-    PYTHON_BIN=""
-    for p in py python3 python; do
-        if command -v "$p" >/dev/null 2>&1 && "$p" -c '' >/dev/null 2>&1; then
-            PYTHON_BIN="$p"
-            break
-        fi
-    done
-    if [ -z "$PYTHON_BIN" ]; then
-        log_message "Skipping 'textual' check: no working Python interpreter found"
-    elif "$PYTHON_BIN" -c "import textual" >/dev/null 2>&1; then
-        log_message "Optional dependency 'textual' already present"
-    else
-        log_message "Installing optional dependency 'textual' for the interactive 'git alias' browser..."
-        if "$PYTHON_BIN" -m pip install textual --quiet >/dev/null 2>&1 || \
-           "$PYTHON_BIN" -m pip install textual --quiet --break-system-packages >/dev/null 2>&1; then
-            log_message "SUCCESS: installed 'textual'"
-        else
-            log_message "WARNING: could not install 'textual'; 'git alias' will use the static table (install manually: pip3 install textual)"
-        fi
-    fi
+    # Ensure the declared Python deps are present (rich required; textual optional,
+    # for the interactive `git alias` browser). Single source of truth: the shared
+    # install_python_deps routine reads pyproject.toml and installs only what is
+    # missing. Best-effort and idempotent — never fails the update.
+    log_message "Checking Python dependencies (rich + optional textual)..."
+    install_python_deps "$REPO_PATH"
 
     # Prune merged branches: drop stale remote-tracking refs, then delete local
     # branches whose upstream remote has been deleted (": gone]"). Mirrors the

--- a/scripts/windows version/Functions.ps1
+++ b/scripts/windows version/Functions.ps1
@@ -1,0 +1,79 @@
+<#
+  Shared PowerShell helpers for the Windows gitconfig scripts. Dot-source it:
+
+    . (Join-Path $PSScriptRoot 'Functions.ps1')
+    Install-PythonDeps -RepoRoot $repoRoot
+
+  Single source of truth for installing the helper's Python dependencies, so
+  install.ps1 and Update-GitConfig.ps1 don't each duplicate the pip logic.
+#>
+
+# Resolve a usable Python: prefer the 'py' launcher, then python3, then python
+# (avoids the Microsoft Store stub when a real interpreter exists). Returns the
+# command name, or $null if none works.
+function Resolve-Python {
+    foreach ($cmd in 'py', 'python3', 'python') {
+        if (Get-Command $cmd -ErrorAction SilentlyContinue) {
+            & $cmd -c '' 2>$null
+            if ($LASTEXITCODE -eq 0) { return $cmd }
+        }
+    }
+    return $null
+}
+
+# Install the Python dependencies declared in pyproject.toml (read via
+# scripts/shared/deps.py): the required deps (rich) plus the optional 'tui' group
+# (textual). Idempotent — only installs what is not already importable. A failed
+# *optional* install is a warning (the helper falls back to a static table).
+# Best-effort; emits status via -Logger (defaults to Write-Host).
+# Usage: Install-PythonDeps -RepoRoot <path> [-Logger { param($m) ... }]
+function Install-PythonDeps {
+    param(
+        [Parameter(Mandatory)][string]$RepoRoot,
+        [scriptblock]$Logger = { param($m) Write-Host $m }
+    )
+    $say = { param($m) & $Logger $m }
+
+    $py = Resolve-Python
+    if (-not $py) { & $say '[WARN] No Python interpreter found; skipping rich/textual (install Python 3, then re-run)'; return }
+
+    $depsPy = Join-Path $RepoRoot 'scripts\shared\deps.py'
+    if (-not (Test-Path $depsPy)) { & $say "[WARN] $depsPy not found; skipping Python dependency install"; return }
+
+    & $py -m pip --version *> $null
+    if ($LASTEXITCODE -ne 0) { & $say "[WARN] pip unavailable for $py; install rich (and optionally textual) manually"; return }
+
+    $required = @(& $py $depsPy required | Where-Object { $_ -ne '' })
+    $optional = @(& $py $depsPy optional | Where-Object { $_ -ne '' })
+
+    # Import name = spec minus any version operator: "rich>=13" -> "rich".
+    $needRequired = @($required | Where-Object { $n = ($_ -split '[<>=!~ ]')[0]; & $py -c "import $n" 2>$null; $LASTEXITCODE -ne 0 })
+    $needOptional = @($optional | Where-Object { $n = ($_ -split '[<>=!~ ]')[0]; & $py -c "import $n" 2>$null; $LASTEXITCODE -ne 0 })
+
+    if ($needRequired.Count -eq 0 -and $needOptional.Count -eq 0) {
+        & $say '[OK] Python dependencies already present (rich + textual)'
+        return
+    }
+
+    if ($needRequired.Count -gt 0) {
+        # Try required + optional together; if that fails, make sure the required
+        # land even when an optional dep is unavailable.
+        if ($needOptional.Count -gt 0) {
+            & $py -m pip install --quiet $needRequired $needOptional 2>$null
+            if ($LASTEXITCODE -eq 0) { & $say "[OK] Installed Python deps: $($needRequired -join ' ') $($needOptional -join ' ')"; return }
+        }
+        & $py -m pip install --quiet $needRequired 2>$null
+        if ($LASTEXITCODE -eq 0) {
+            if ($needOptional.Count -gt 0) { & $say "[OK] Installed required Python deps: $($needRequired -join ' ') (optional unavailable; 'git alias' uses the static table)" }
+            else { & $say "[OK] Installed required Python deps: $($needRequired -join ' ')" }
+        }
+        else {
+            & $say "[WARN] Could not install required Python deps ($($needRequired -join ' ')) - run: $py -m pip install $($needRequired -join ' ')"
+        }
+    }
+    elseif ($needOptional.Count -gt 0) {
+        & $py -m pip install --quiet $needOptional 2>$null
+        if ($LASTEXITCODE -eq 0) { & $say "[OK] Installed optional Python deps: $($needOptional -join ' ')" }
+        else { & $say "[WARN] Optional Python deps unavailable ($($needOptional -join ' ')); 'git alias' uses the static table" }
+    }
+}

--- a/scripts/windows version/Update-GitConfig.ps1
+++ b/scripts/windows version/Update-GitConfig.ps1
@@ -67,33 +67,12 @@ try {
         Write-Log "ERROR: convergence failed (exit code $LASTEXITCODE)"
     }
 
-    # Step 2c: Ensure the optional 'textual' dependency (for the interactive
-    # `git alias` browser) is present. Best-effort and idempotent: resolves the
-    # interpreter py -> python3 -> python (avoiding the Microsoft Store stub),
-    # only installs when missing, and never fails the update if it cannot.
-    $pyCmd = if (Get-Command py -ErrorAction SilentlyContinue)          { "py" }
-             elseif (Get-Command python3 -ErrorAction SilentlyContinue) { "python3" }
-             elseif (Get-Command python -ErrorAction SilentlyContinue)  { "python" }
-             else { $null }
-    if (-not $pyCmd) {
-        Write-Log "Skipping 'textual' check: no Python interpreter found"
-    }
-    else {
-        & $pyCmd -c "import textual" 2>$null
-        if ($LASTEXITCODE -eq 0) {
-            Write-Log "Optional dependency 'textual' already present"
-        }
-        else {
-            Write-Log "Installing optional dependency 'textual' for the interactive 'git alias' browser..."
-            & $pyCmd -m pip install textual --quiet 2>$null
-            if ($LASTEXITCODE -eq 0) {
-                Write-Log "SUCCESS: installed 'textual'"
-            }
-            else {
-                Write-Log "WARNING: could not install 'textual'; 'git alias' will use the static table (install manually: pip install textual)"
-            }
-        }
-    }
+    # Step 2c: Ensure the declared Python deps are present (rich required; textual
+    # optional, for the interactive `git alias` browser). Single source of truth:
+    # the shared Install-PythonDeps routine reads pyproject.toml and installs only
+    # what is missing. Best-effort and idempotent — never fails the update.
+    . (Join-Path $PSScriptRoot 'Functions.ps1')
+    Install-PythonDeps -RepoRoot $RepoPath -Logger { param($m) Write-Log $m }
 
     # Step 3: Prune merged branches. Drop stale remote-tracking refs, then delete
     # local branches whose upstream remote has been deleted (": gone]"). Mirrors

--- a/scripts/windows version/install.ps1
+++ b/scripts/windows version/install.ps1
@@ -153,47 +153,14 @@ if (-not $NoTask) {
     Write-Host ""
 }
 
-# STEP 6: Install Python dependencies
+# STEP 6: Install Python dependencies (rich required; textual optional, for the
+# interactive 'git alias' browser). Declared in pyproject.toml and installed by
+# the shared Install-PythonDeps routine (single source of truth across Windows
+# install + the login auto-update).
 Write-Host "[STEP 6] Installing Python dependencies..." -ForegroundColor Cyan
 Write-Host "-----" -ForegroundColor Cyan
-$pip = Get-Command pip -ErrorAction SilentlyContinue
-$pip3 = Get-Command pip3 -ErrorAction SilentlyContinue
-$pipCmd = if ($pip3) { "pip3" } elseif ($pip) { "pip" } else { $null }
-
-# 'rich' is required for the helper's tables; 'textual' is optional and only
-# powers the interactive 'git alias' browser (the helper falls back to a static
-# table without it), so a failed textual install is a warning, not an error.
-if ($pipCmd) {
-    $richCheck = & $pipCmd show rich 2>$null
-    $textualCheck = & $pipCmd show textual 2>$null
-    if ($richCheck -and $textualCheck) {
-        Write-Host "[OK] Python 'rich' and 'textual' already installed" -ForegroundColor Green
-    }
-    else {
-        try {
-            & $pipCmd install rich textual --quiet 2>$null
-            if ($LASTEXITCODE -eq 0) {
-                Write-Host "[OK] Installed Python 'rich' and 'textual'" -ForegroundColor Green
-            }
-            else {
-                # textual is optional; make sure the required 'rich' still lands.
-                & $pipCmd install rich --quiet 2>$null
-                if ($LASTEXITCODE -eq 0) {
-                    Write-Host "[OK] Installed Python 'rich' (textual unavailable; 'git alias' uses the static table)" -ForegroundColor Green
-                }
-                else {
-                    Write-Host "[WARN] Could not install 'rich' - run manually: pip install rich textual" -ForegroundColor Yellow
-                }
-            }
-        }
-        catch {
-            Write-Host "[WARN] Could not install 'rich' - run manually: pip install rich textual" -ForegroundColor Yellow
-        }
-    }
-}
-else {
-    Write-Host "[WARN] pip not found - install Python 3 from https://python.org" -ForegroundColor Yellow
-}
+. (Join-Path $scriptDir 'Functions.ps1')
+Install-PythonDeps -RepoRoot $repoRoot
 Write-Host ""
 
 # STEP 6b: Enable the interactive git-alias browser keybinding (Ctrl-G)

--- a/tests/Setup-GitConfig.Tests.ps1
+++ b/tests/Setup-GitConfig.Tests.ps1
@@ -56,19 +56,23 @@ Describe "install.ps1" {
     }
 
     Context "Python Dependencies" {
-        It "Should attempt to install Python rich library" {
+        # The install logic now lives in the shared Install-PythonDeps routine
+        # (scripts/windows version/Functions.ps1), driven by the pyproject.toml
+        # manifest. install.ps1 just delegates to it.
+        It "Should delegate Python dependency install to the shared Install-PythonDeps routine" {
             $scriptContent = Get-Content $script:scriptPath -Raw
-            $scriptContent | Should -Match "pip.*install.*rich"
+            $scriptContent | Should -Match "Install-PythonDeps"
         }
 
-        It "Should verify rich is importable" {
-            $scriptContent = Get-Content $script:scriptPath -Raw
-            $scriptContent | Should -Match "import rich"
+        It "Should declare 'rich' (required) in pyproject.toml" {
+            $pyproject = Get-Content (Join-Path $script:repoRoot "pyproject.toml") -Raw
+            $pyproject | Should -Match "rich"
         }
 
-        It "Should warn gracefully if pip is not available" {
-            $scriptContent = Get-Content $script:scriptPath -Raw
-            $scriptContent | Should -Match "\[WARN\].*pip"
+        It "The shared routine should pip-install deps and warn gracefully without pip" {
+            $functions = Get-Content (Join-Path $script:repoRoot "scripts\windows version\Functions.ps1") -Raw
+            $functions | Should -Match "pip install"
+            $functions | Should -Match "\[WARN\].*pip"
         }
     }
 

--- a/tests/Update-GitConfig.Tests.ps1
+++ b/tests/Update-GitConfig.Tests.ps1
@@ -79,11 +79,16 @@ Describe "Update-GitConfig.ps1" {
             $scriptContent | Should -Match 'param\s*\(\s*\[string\]\s*\$RepoPath'
         }
 
-        It "Should ensure the optional 'textual' dependency (idempotent, best-effort)" {
+        It "Should ensure Python deps via the shared Install-PythonDeps routine (idempotent, best-effort)" {
             $scriptContent = Get-Content $script:scriptPath -Raw
-            # Checks presence before installing so repeat runs are a no-op.
-            $scriptContent | Should -Match 'import textual'
-            $scriptContent | Should -Match 'pip install textual'
+            # The dep logic now lives in the shared routine; the update just calls it.
+            $scriptContent | Should -Match 'Install-PythonDeps'
+        }
+
+        It "Should declare 'textual' as an optional (tui) dependency in pyproject.toml" {
+            $repoRoot = Split-Path -Parent $PSScriptRoot
+            $pyproject = Get-Content (Join-Path $repoRoot "pyproject.toml") -Raw
+            $pyproject | Should -Match 'textual'
         }
     }
 


### PR DESCRIPTION
Fixes #153

## Problem

The helper's Python deps — `rich` (required) and `textual` (optional, for the `git alias` TUI) — had **no manifest** and were installed by **five near-identical pip blocks** duplicated across `scripts/mac version/install.sh`, `scripts/linux version/install.sh`, `scripts/shared/update-gitconfig.sh`, `scripts/windows version/install.ps1`, and `Update-GitConfig.ps1`.

## Change

- **`pyproject.toml`** — single declared manifest: `rich` required; `textual` under the `[project.optional-dependencies].tui` extra. Declaration only (no `[build-system]`; the repo is scripts, not a pip-installable package).
- **`scripts/shared/deps.py`** — dependency-free reader (no third-party imports, since it bootstraps installing `rich`) that prints the declared specs one per line. `tomllib` with a regex fallback for Python < 3.11.
- **One routine per platform family**, both reading the manifest:
  - `install_python_deps` in `scripts/shared/functions.sh` (bash — mac/linux install + login auto-update)
  - `Install-PythonDeps` in the new `scripts/windows version/Functions.ps1` (PowerShell — `install.ps1` + `Update-GitConfig.ps1`)
- Replaced the five duplicated blocks with calls. Behaviour unchanged: idempotent, `py`→`python3`→`python` resolution, `--break-system-packages` fallback, optional-dep failure stays a warning.
- Retargeted the Pester tests (`Setup-GitConfig.Tests.ps1`, `Update-GitConfig.Tests.ps1`) to the new structure.

## Testing

- `bash -n` clean on all four bash files; `deps.py` compiles, and both the tomllib path and the regex fallback extract `rich>=13` / `textual>=0.50`.
- `install_python_deps` no-op path verified live on macOS (both deps present → "already present").
- `pwsh` parses all three PS scripts + both test files; `Install-PythonDeps` runs the no-op path live on macOS `pwsh`.
- Pester itself isn't available on this machine (Windows/VM only per the repo's testing notes); the updated assertions' grep patterns were confirmed against the new file contents.

Part of the cross-repo dependency-handling pass (gitconfig ↔ claude-skills).