### PR TITLE
feat: cross-repo guard for 'git skill'; git preflight in installers

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -21,11 +21,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `git clone … && setup` to fix it) instead of a generic "directory not found" or "wrapper script not
   found". `git skill help` and unknown-subcommand handling still work without the repo. Covered by new
   pytest cases in `tests/shared/test_gitconfig_helper.py`
-  ([#155](https://github.com/J-MaFf/gitconfig/issues/155))
+  ([#156](https://github.com/J-MaFf/gitconfig/pull/156), closes [#155](https://github.com/J-MaFf/gitconfig/issues/155))
 - **`git` preflight in the installers** — `scripts/{mac,linux} version/install.sh` and
   `scripts/windows version/install.ps1` now verify `git` is on `PATH` up front and exit with an
   "install git" message, rather than failing partway through (the whole tool configures git)
-  ([#155](https://github.com/J-MaFf/gitconfig/issues/155))
+  ([#156](https://github.com/J-MaFf/gitconfig/pull/156))
 
 ### Changed
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -14,6 +14,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `[project.optional-dependencies].tui` extra. Declaration only — the repo is scripts, not a
   pip-installable package. A dependency-free `scripts/shared/deps.py` reads it (tomllib with a
   regex fallback for Python < 3.11) ([#154](https://github.com/J-MaFf/gitconfig/pull/154), closes [#153](https://github.com/J-MaFf/gitconfig/issues/153))
+- **Cross-repo guard for `git skill`** — the `git skill <cmd>` aliases dispatch into
+  `~/.claude/skills/scripts/*`, which live in the separate [claude-skills](https://github.com/J-MaFf/claude-skills)
+  repo. When that repo isn't installed at `~/.claude/skills`, every subcommand (`list`/`sync`/`status`/
+  `publish`) now stops with one clear, actionable message (what's missing, where it comes from, and the
+  `git clone … && setup` to fix it) instead of a generic "directory not found" or "wrapper script not
+  found". `git skill help` and unknown-subcommand handling still work without the repo. Covered by new
+  pytest cases in `tests/shared/test_gitconfig_helper.py`
+  ([#155](https://github.com/J-MaFf/gitconfig/issues/155))
+- **`git` preflight in the installers** — `scripts/{mac,linux} version/install.sh` and
+  `scripts/windows version/install.ps1` now verify `git` is on `PATH` up front and exit with an
+  "install git" message, rather than failing partway through (the whole tool configures git)
+  ([#155](https://github.com/J-MaFf/gitconfig/issues/155))
 
 ### Changed
 

--- a/gitconfig_helper.py
+++ b/gitconfig_helper.py
@@ -345,6 +345,30 @@ def _skill_last_updated(skills_dir, name, skill_md_path):
         return "unknown"
 
 
+# The claude-skills repo, cloned to ~/.claude/skills, supplies both the skills
+# themselves and the wrapper scripts that `git skill sync/status/publish` drive.
+# It is a SEPARATE repo (https://github.com/J-MaFf/claude-skills); gitconfig only
+# provides the `git skill` UX layer on top of it. So every `git skill` subcommand
+# depends on that repo being installed there.
+SKILLS_DIR = os.path.join(os.path.expanduser("~"), ".claude", "skills")
+
+
+def _require_skills_dir():
+    """Return True if ~/.claude/skills exists, else print an actionable pointer to
+    the claude-skills repo and return False."""
+    if os.path.isdir(SKILLS_DIR):
+        return True
+    Console(stderr=True).print(
+        f"[red]git skill: {SKILLS_DIR} not found — the claude-skills repo isn't "
+        f"installed on this machine.[/red]\n"
+        f"[yellow]It's a separate repo that supplies the skills and the wrapper "
+        f"scripts these aliases drive. Install it:[/yellow]\n"
+        f"  git clone https://github.com/J-MaFf/claude-skills.git ~/.claude/skills\n"
+        f"  # then run its per-OS setup, e.g.:  sh ~/.claude/skills/scripts/setup-macos.sh"
+    )
+    return False
+
+
 def list_skills():
     """Print installed Claude skills (~/.claude/skills) as a rich table.
 
@@ -353,7 +377,7 @@ def list_skills():
     date it was last updated (last commit touching it, else the file mtime).
     """
     console = Console()
-    skills_dir = os.path.join(os.path.expanduser("~"), ".claude", "skills")
+    skills_dir = SKILLS_DIR
     if not os.path.isdir(skills_dir):
         console.print(f"[red]Skills directory not found: {skills_dir}[/red]")
         return 1
@@ -414,7 +438,7 @@ def _run_skill_script(base):
     Picks the per-OS variant: PowerShell on Windows, bash elsewhere. Returns the
     script's exit code, or 1 if the expected script file is missing.
     """
-    scripts_dir = os.path.join(os.path.expanduser("~"), ".claude", "skills", "scripts")
+    scripts_dir = os.path.join(SKILLS_DIR, "scripts")
     if sys.platform == "win32":
         script = os.path.join(scripts_dir, base + ".ps1")
         cmd = ["powershell", "-NoProfile", "-ExecutionPolicy", "Bypass", "-File", script]
@@ -444,18 +468,21 @@ def skill(args):
     wrapper scripts shipped in the claude-skills repo (see SKILL_SCRIPTS).
     """
     sub = args[0] if args else ""
-    if sub == "list":
-        return list_skills()
-    if sub in SKILL_SCRIPTS:
-        return _run_skill_script(SKILL_SCRIPTS[sub])
     if sub in ("", "help", "-h", "--help"):
         Console().print(SKILL_USAGE)
         return 0
-    Console(stderr=True).print(
-        f"[red]git skill: unknown subcommand '{sub}' "
-        f"(try: list, sync, status, publish)[/red]"
-    )
-    return 1
+    if sub != "list" and sub not in SKILL_SCRIPTS:
+        Console(stderr=True).print(
+            f"[red]git skill: unknown subcommand '{sub}' "
+            f"(try: list, sync, status, publish)[/red]"
+        )
+        return 1
+    # All real subcommands need the claude-skills repo at ~/.claude/skills.
+    if not _require_skills_dir():
+        return 1
+    if sub == "list":
+        return list_skills()
+    return _run_skill_script(SKILL_SCRIPTS[sub])
 
 
 # Issue labels -> branch-name prefix, per the git-policies branch conventions.

--- a/scripts/linux version/install.sh
+++ b/scripts/linux version/install.sh
@@ -8,6 +8,11 @@
 
 set -e
 
+# Preflight: git is required throughout (this whole tool configures git). A clear
+# "install git" beats a cryptic mid-run failure. Python is checked later by
+# install_python_deps, which degrades gracefully if it's missing.
+command -v git >/dev/null 2>&1 || { echo "[ERROR] git not found on PATH. Install git (sudo apt install git), then re-run." >&2; exit 1; }
+
 FORCE=false
 NO_CRON=false
 HELP=false

--- a/scripts/mac version/install.sh
+++ b/scripts/mac version/install.sh
@@ -9,6 +9,11 @@
 
 set -e
 
+# Preflight: git is required throughout (this whole tool configures git). A clear
+# "install git" beats a cryptic mid-run failure. Python is checked later by
+# install_python_deps, which degrades gracefully if it's missing.
+command -v git >/dev/null 2>&1 || { echo "[ERROR] git not found on PATH. Install git (brew install git), then re-run." >&2; exit 1; }
+
 FORCE=false
 NO_LAUNCHD=false
 HELP=false

--- a/scripts/windows version/install.ps1
+++ b/scripts/windows version/install.ps1
@@ -31,6 +31,14 @@ REQUIREMENTS: Administrator privileges
     exit 0
 }
 
+# Preflight: git is required throughout (this whole tool configures git). A clear
+# "install git" beats a cryptic mid-run failure. Python is checked later by
+# Install-PythonDeps, which degrades gracefully if it's missing.
+if (-not (Get-Command git -ErrorAction SilentlyContinue)) {
+    Write-Error 'git not found on PATH. Install Git for Windows (winget install Git.Git), then re-run.'
+    exit 1
+}
+
 # Check if running as administrator - elevate if needed
 $isAdmin = ([Security.Principal.WindowsPrincipal][Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)
 if (-not $isAdmin) {

--- a/tests/shared/test_gitconfig_helper.py
+++ b/tests/shared/test_gitconfig_helper.py
@@ -199,5 +199,36 @@ class TestGetGitAliases:
         assert helper.get_git_aliases() == []
 
 
+# --------------------------------------------------------------------------
+# _require_skills_dir / skill() cross-repo guard
+# --------------------------------------------------------------------------
+
+class TestSkillCrossRepoGuard:
+    """`git skill` depends on the separate claude-skills repo at ~/.claude/skills.
+    The guard must allow help/usage and unknown-subcommand handling without it,
+    but block the real subcommands with an actionable pointer when it's missing."""
+
+    def test_require_true_when_dir_exists(self, helper, tmp_path, monkeypatch):
+        monkeypatch.setattr(helper, "SKILLS_DIR", str(tmp_path))
+        assert helper._require_skills_dir() is True
+
+    def test_require_false_when_dir_missing(self, helper, tmp_path, monkeypatch):
+        monkeypatch.setattr(helper, "SKILLS_DIR", str(tmp_path / "nope"))
+        assert helper._require_skills_dir() is False
+
+    def test_skill_list_blocked_when_repo_missing(self, helper, tmp_path, monkeypatch):
+        monkeypatch.setattr(helper, "SKILLS_DIR", str(tmp_path / "nope"))
+        assert helper.skill(["list"]) == 1
+
+    def test_help_and_usage_work_without_repo(self, helper, tmp_path, monkeypatch):
+        monkeypatch.setattr(helper, "SKILLS_DIR", str(tmp_path / "nope"))
+        assert helper.skill(["help"]) == 0
+        assert helper.skill([]) == 0
+
+    def test_unknown_subcommand_errors_without_repo(self, helper, tmp_path, monkeypatch):
+        monkeypatch.setattr(helper, "SKILLS_DIR", str(tmp_path / "nope"))
+        assert helper.skill(["bogus"]) == 1
+
+
 if __name__ == "__main__":
     sys.exit(pytest.main([__file__, "-v"]))


### PR DESCRIPTION
Fixes #155

## Problem

**Cross-repo dependency (gitconfig → claude-skills):** `git skill <cmd>` dispatches into `~/.claude/skills/scripts/*`, which live in the separate **claude-skills** repo. If it isn't installed at `~/.claude/skills`, the failures are unhelpful — `git skill list` → generic "Skills directory not found"; `sync`/`status`/`publish` → cryptic "wrapper script not found: <path>".

**Installer preflight:** mac/linux `install.sh` and `install.ps1` didn't verify `git` up front.

## Change

- **`gitconfig_helper.py`** — centralize `SKILLS_DIR` and add `_require_skills_dir()`. Every real `git skill` subcommand now stops with one clear, actionable message: *what's* missing, that it comes from the separate claude-skills repo, and the `git clone … && setup` to fix it. `git skill help` / usage / unknown-subcommand handling still work **without** the repo.
- **`git` preflight** at the top of `scripts/{mac,linux} version/install.sh` and `scripts/windows version/install.ps1` — exit with an "install git" message instead of failing mid-run.

## Testing

- `pytest tests/shared/test_gitconfig_helper.py` → **25 passed** (5 new guard cases: require true/false; `list` blocked when missing; `help`/usage + unknown subcommand still work without the repo).
- `bash -n` clean on both installers; `pwsh` parses `install.ps1`.
- Manual: `git skill list` lists the table with the repo present; with a fake `HOME` it prints the guard message + clone/setup instructions; `git skill help` and `git skill bogus` behave correctly without the repo.

Part of the cross-repo dependency-handling pass (gitconfig ↔ claude-skills) — the counterpart to claude-skills #100, which documents the reverse (optional) direction.