### PR TITLE
ci: add Dependabot (GitHub Actions + pip/pyproject ecosystems)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,35 @@
+version: 2
+updates:
+  # Keep the GitHub Actions in .github/workflows current. Grouped into one weekly
+  # PR (only a couple of actions are pinned, so per-action PRs would be noise).
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "ci"
+    assignees:
+      - "J-MaFf"
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+
+  # Track the Python deps declared in pyproject.toml (rich, textual). They are
+  # floor-pinned (>=), so version bumps are rare — the main value here is
+  # Dependabot SECURITY updates for these packages. Requires pyproject.toml,
+  # added in PR #154; merge that first so this ecosystem has a manifest.
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "deps"
+    assignees:
+      - "J-MaFf"
+    groups:
+      python:
+        patterns:
+          - "*"

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -26,6 +26,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `scripts/windows version/install.ps1` now verify `git` is on `PATH` up front and exit with an
   "install git" message, rather than failing partway through (the whole tool configures git)
   ([#156](https://github.com/J-MaFf/gitconfig/pull/156))
+- **Dependabot** (`.github/dependabot.yml`) — weekly, grouped, J-MaFf-assigned updates for two
+  ecosystems: **github-actions** (the workflow action pins) and **pip** (the `rich`/`textual` deps
+  declared in `pyproject.toml`; floor-pinned, so the pip value is mainly Dependabot security
+  updates). Conventional `ci:` / `deps:` commit prefixes. The pip ecosystem needs `pyproject.toml`
+  (added in [#154](https://github.com/J-MaFf/gitconfig/pull/154) — merge that first)
+  ([#157](https://github.com/J-MaFf/gitconfig/issues/157))
 
 ### Changed
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -31,7 +31,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   declared in `pyproject.toml`; floor-pinned, so the pip value is mainly Dependabot security
   updates). Conventional `ci:` / `deps:` commit prefixes. The pip ecosystem needs `pyproject.toml`
   (added in [#154](https://github.com/J-MaFf/gitconfig/pull/154) — merge that first)
-  ([#157](https://github.com/J-MaFf/gitconfig/issues/157))
+  ([#158](https://github.com/J-MaFf/gitconfig/pull/158), closes [#157](https://github.com/J-MaFf/gitconfig/issues/157))
 
 ### Changed
 


### PR DESCRIPTION
Fixes #157

## Change

Add `.github/dependabot.yml` with two weekly, grouped, J-MaFf-assigned ecosystems:

- **github-actions** (`/`) — keeps the workflow action pins current (e.g. it'll propose the `actions/checkout@v6` → `@v7` bump as a reviewable PR).
- **pip** (`/`) — tracks the `rich` / `textual` deps declared in `pyproject.toml`. They're floor-pinned (`>=`), so routine version bumps are rare; the real value is **Dependabot security updates** for these packages via the dependency graph.

Conventional commit prefixes (`ci:` / `deps:`), grouped so each ecosystem lands one PR per week.

## Merge order

The **pip** ecosystem needs `pyproject.toml`, which is added in #154 — **merge #154 first** (or together). Until then Dependabot just logs "manifest not found" for the pip ecosystem; github-actions is unaffected.

## Testing

- `dependabot.yml` parses as valid YAML (ruby `YAML.load_file`); 2 ecosystems declared.

Part of the cross-repo dependency-handling pass (gitconfig ↔ claude-skills); mirrors claude-skills #102.