### PR TITLE
fix: resolve real Python when WindowsApps alias stubs shadow PATH

### DIFF
--- a/scripts/windows version/Functions.ps1
+++ b/scripts/windows version/Functions.ps1
@@ -9,21 +9,53 @@
 #>
 
 # Resolve a usable Python: prefer the 'py' launcher, then python3, then python
-# (avoids the Microsoft Store stub when a real interpreter exists). Returns the
-# command name, or $null if none works.
+# (avoids the Microsoft Store stub when a real interpreter exists). Returns a
+# command name or full path that works, or $null if none does.
+#
+# Why this is more than a simple Get-Command: the Python Install Manager
+# (PyManager) and the Store register their entry points as 0-byte "app execution
+# alias" reparse points under %LOCALAPPDATA%\Microsoft\WindowsApps. Those aliases
+# only resolve in an interactive desktop session, so they FAIL in a scheduled
+# task running hidden at logon (`py -c ''` returns non-zero). Since py/python3/
+# python all point at the same WindowsApps stubs, the old loop returned $null
+# even though a real interpreter was installed. We therefore enumerate ALL
+# matches (Get-Command -All), skip 0-byte WindowsApps stubs, and add the real
+# launcher install paths as explicit fallbacks.
 function Resolve-Python {
+    $candidates = [System.Collections.Generic.List[string]]::new()
+
     foreach ($cmd in 'py', 'python3', 'python') {
-        if (Get-Command $cmd -ErrorAction SilentlyContinue) {
-            & $cmd -c '' 2>$null
-            if ($LASTEXITCODE -eq 0) { return $cmd }
+        foreach ($g in @(Get-Command $cmd -All -ErrorAction SilentlyContinue)) {
+            $src = $g.Source
+            if (-not $src) { continue }
+            # Skip 0-byte WindowsApps app-execution-alias stubs (don't even run
+            # them - invoking a Store stub can pop the install prompt).
+            if ($src -like '*\Microsoft\WindowsApps\*' -and (Test-Path $src) -and ((Get-Item $src).Length -eq 0)) { continue }
+            if (-not $candidates.Contains($src)) { $candidates.Add($src) }
         }
+    }
+
+    # Explicit fallbacks: the real launcher / PyManager install locations, in
+    # case PATH in the task context doesn't reach them.
+    if ($env:LOCALAPPDATA) {
+        foreach ($fb in @(
+                (Join-Path $env:LOCALAPPDATA 'Programs\Python\Launcher\py.exe'),
+                (Join-Path $env:LOCALAPPDATA 'Programs\Python\py.exe')
+            )) {
+            if ((Test-Path $fb) -and (-not $candidates.Contains($fb))) { $candidates.Add($fb) }
+        }
+    }
+
+    foreach ($cand in $candidates) {
+        & $cand -c '' 2>$null
+        if ($LASTEXITCODE -eq 0) { return $cand }
     }
     return $null
 }
 
 # Install the Python dependencies declared in pyproject.toml (read via
 # scripts/shared/deps.py): the required deps (rich) plus the optional 'tui' group
-# (textual). Idempotent — only installs what is not already importable. A failed
+# (textual). Idempotent - only installs what is not already importable. A failed
 # *optional* install is a warning (the helper falls back to a static table).
 # Best-effort; emits status via -Logger (defaults to Write-Host).
 # Usage: Install-PythonDeps -RepoRoot <path> [-Logger { param($m) ... }]


### PR DESCRIPTION
Fixes #160

## Problem

The `GitConfig Pull at Login` scheduled task logged `[WARN] No Python interpreter found; skipping rich/textual` even though Python (Python Install Manager / PyManager 3.14.4) is installed and works fine when invoked manually.

## Root cause

`Resolve-Python` in `scripts/windows version/Functions.ps1` used `Get-Command py`, which returns the **first** match on `PATH`:

```
C:\Users\<user>\AppData\Local\Microsoft\WindowsApps\py.exe   (0-byte app-execution-alias stub)
```

Those Microsoft "app execution aliases" are 0-byte reparse points that only resolve in an **interactive desktop session**. When the scheduled task runs hidden at logon, the alias does not resolve, `py -c ''` exits non-zero, and since `py`/`python3`/`python` all point at the same WindowsApps stubs, `Resolve-Python` returned `$null`. The real launcher (`%LOCALAPPDATA%\Programs\Python\Launcher\py.exe`) is on `PATH` but *after* WindowsApps, so `Get-Command` never reached it. This is why `git alias` / manual runs work but the logon task doesn't.

## Fix

`Resolve-Python` now:
- enumerates **all** matches via `Get-Command -All`,
- skips 0-byte WindowsApps alias stubs (without invoking them, so the Store install prompt can't pop),
- falls back to the real PyManager / launcher install paths under `%LOCALAPPDATA%\Programs\Python`.

Also made `Functions.ps1` ASCII-clean (replaced two em-dashes) so it passes `Encoding.Tests.ps1` (Windows PowerShell 5.1 compatibility).

## Testing

```text
# Manual resolution now returns the real launcher, not the stub:
Resolve-Python => C:\Users\<user>\AppData\Local\Programs\Python\Launcher\py.exe
Python 3.14.4

# Pester (this file's coverage):
Update-GitConfig.Tests.ps1 + Setup-GitConfig.Tests.ps1  -> 33 passed, 0 failed
Encoding.Tests.ps1 (Functions.ps1)                      -> passes
```