### PR TITLE
fix: replace non-ASCII em-dashes to satisfy Encoding tests

### DIFF
--- a/gitconfig_helper.py
+++ b/gitconfig_helper.py
@@ -359,7 +359,7 @@ def _require_skills_dir():
     if os.path.isdir(SKILLS_DIR):
         return True
     Console(stderr=True).print(
-        f"[red]git skill: {SKILLS_DIR} not found — the claude-skills repo isn't "
+        f"[red]git skill: {SKILLS_DIR} not found - the claude-skills repo isn't "
         f"installed on this machine.[/red]\n"
         f"[yellow]It's a separate repo that supplies the skills and the wrapper "
         f"scripts these aliases drive. Install it:[/yellow]\n"

--- a/scripts/windows version/Update-GitConfig.ps1
+++ b/scripts/windows version/Update-GitConfig.ps1
@@ -70,7 +70,7 @@ try {
     # Step 2c: Ensure the declared Python deps are present (rich required; textual
     # optional, for the interactive `git alias` browser). Single source of truth:
     # the shared Install-PythonDeps routine reads pyproject.toml and installs only
-    # what is missing. Best-effort and idempotent — never fails the update.
+    # what is missing. Best-effort and idempotent - never fails the update.
     . (Join-Path $PSScriptRoot 'Functions.ps1')
     Install-PythonDeps -RepoRoot $RepoPath -Logger { param($m) Write-Log $m }
 


### PR DESCRIPTION
Fixes #163

## Problem

`tests/Encoding.Tests.ps1` enforces ASCII-only source (non-ASCII breaks Windows PowerShell 5.1 parsing; non-ASCII glyphs can crash `rich` on the legacy Windows console). Two files contained `U+2014` em-dashes:

- `scripts/windows version/Update-GitConfig.ps1:73` — comment
- `gitconfig_helper.py:362` — user-facing `rich` string

## Fix

Replaced both em-dashes with an ASCII hyphen (`-`).

## Testing

```text
both files now ASCII-clean (grep -P '[^\x00-\x7F]' -> no matches)
gitconfig_helper.py: ast.parse OK
Encoding.Tests.ps1: only remaining failure is Functions.ps1, fixed separately in #161
```

> Note: `Functions.ps1` had the same issue and is fixed in #161. With both merged, `Encoding.Tests.ps1` is fully green.