### PR TITLE
feat: preserve existing ~/.gitconfig.local on re-install (create-if-missing)

### DIFF
--- a/scripts/windows version/Cleanup-GitConfig.ps1
+++ b/scripts/windows version/Cleanup-GitConfig.ps1
@@ -4,7 +4,8 @@
 
 param(
     [switch]$Help = $false,
-    [switch]$Force = $false
+    [switch]$Force = $false,
+    [switch]$KeepLocal = $false
 )
 
 if ($Help) {
@@ -14,14 +15,17 @@ GitConfig Cleanup Script
 USAGE: .\Cleanup-GitConfig.ps1 [OPTIONS]
 
 OPTIONS:
-    -Force   Skip confirmation prompts
-    -Help    Display this help message
+    -Force      Skip confirmation prompts
+    -KeepLocal  Preserve ~/.gitconfig.local (machine-specific user config).
+                Used by install.ps1's preflight so re-running setup never wipes
+                hand-tuned safe.directory entries, etc.
+    -Help       Display this help message
 
 DESCRIPTION:
     Removes all gitconfig-related setup:
     1. Backs up and removes .gitconfig (generated file)
     2. Removes symlinks (.gitignore_global and gitconfig_helper.py)
-    3. Removes .gitconfig.local
+    3. Removes .gitconfig.local (unless -KeepLocal)
     4. Deletes scheduled task (if it exists)
     5. Clears git SSH signing config
 
@@ -109,7 +113,10 @@ Write-Host "[STEP 2] Removing .gitconfig.local..." -ForegroundColor Cyan
 Write-Host "-----" -ForegroundColor Cyan
 
 $localConfigPath = "$homeDir\.gitconfig.local"
-if (Test-Path $localConfigPath) {
+if ($KeepLocal) {
+    Write-Host "[SKIP] Preserving .gitconfig.local (-KeepLocal)" -ForegroundColor Yellow
+}
+elseif (Test-Path $localConfigPath) {
     try {
         $backupName = "Existing.gitconfig.local.bak"
         $backupPath = Join-Path $homeDir $backupName
@@ -201,8 +208,11 @@ foreach ($file in $filesToRemove) {
     }
 }
 
-# Check .gitconfig.local was removed
-if (Test-Path $localConfigPath) {
+# Check .gitconfig.local was removed (skipped when intentionally preserved)
+if ($KeepLocal) {
+    Write-Host "[OK] .gitconfig.local preserved (-KeepLocal)" -ForegroundColor Green
+}
+elseif (Test-Path $localConfigPath) {
     Write-Host "[FAIL] .gitconfig.local still exists!" -ForegroundColor Red
     $verifyErrors++
 }

--- a/scripts/windows version/Initialize-LocalConfig.ps1
+++ b/scripts/windows version/Initialize-LocalConfig.ps1
@@ -15,18 +15,24 @@ USAGE:
     .\Initialize-LocalConfig.ps1 [OPTIONS]
 
 OPTIONS:
-    -Force      Overwrite existing .gitconfig.local without prompting
+    -Force      Regenerate (overwrite) an existing .gitconfig.local from the
+                template. Without -Force, an existing file is preserved.
     -Help       Display this help message
 
 DESCRIPTION:
     Creates ~/.gitconfig.local with machine-specific safe directories and paths.
     This file is included by the main .gitconfig and should NOT be version controlled.
 
+    Create-if-missing: because this file holds user-owned machine state (hand-tuned
+    safe.directory entries, etc.), an existing one is preserved by default; pass
+    -Force to regenerate it from the template. The allowed_signers file is always
+    ensured (idempotently), even when the config itself is preserved.
+
 EXAMPLE:
-    # Interactive mode (prompts before overwriting)
+    # Create if missing; preserve an existing file
     .\Initialize-LocalConfig.ps1
 
-    # Force mode (overwrites without prompting)
+    # Regenerate from template, overwriting the existing file
     .\Initialize-LocalConfig.ps1 -Force
 
 SAFE DIRECTORIES:
@@ -106,18 +112,17 @@ Write-Host "Home Directory: $homeDir" -ForegroundColor Green
 Write-Host "Local Config Path: $localConfigPath" -ForegroundColor Green
 Write-Host ""
 
-# Check if .gitconfig.local already exists
-if ((Test-Path $localConfigPath) -and -not $Force) {
-    Write-Host ".gitconfig.local already exists." -ForegroundColor Yellow
-    $response = Read-Host "Overwrite? (y/n)"
-    if ($response -ne "y") {
-        Write-Host "Cancelled." -ForegroundColor Yellow
-        exit 0
-    }
-}
+# Create-if-missing: .gitconfig.local holds user-owned machine state (safe.directory
+# entries, etc.), so never clobber an existing one. Regenerate deliberately with -Force.
+$localConfigExists = Test-Path $localConfigPath
 
 try {
-    $configContent = @"
+    if ($localConfigExists -and -not $Force) {
+        Write-Host "[SKIP] .gitconfig.local already exists; preserving machine-specific config" -ForegroundColor Yellow
+        Write-Host "       (regenerate from template with: Initialize-LocalConfig.ps1 -Force)" -ForegroundColor DarkGray
+    }
+    else {
+        $configContent = @"
 # Machine-Specific Git Configuration
 # This file is automatically included by .gitconfig and should NOT be committed
 
@@ -148,9 +153,15 @@ try {
 	directory = $($homeDir -replace '\\', '/')/Documents/Scripts/winget-install
 "@
 
-    # Create or overwrite the local config file
-    Set-Content -Path $localConfigPath -Value $configContent -Force
-    Write-Host "[OK] Created .gitconfig.local" -ForegroundColor Green
+        # Create or overwrite the local config file
+        Set-Content -Path $localConfigPath -Value $configContent -Force
+        if ($localConfigExists) {
+            Write-Host "[OK] Regenerated .gitconfig.local (-Force)" -ForegroundColor Green
+        }
+        else {
+            Write-Host "[OK] Created .gitconfig.local" -ForegroundColor Green
+        }
+    }
     Write-Host ""
 
     # Build ~/.ssh/allowed_signers so git can verify SSH commit signatures locally.

--- a/scripts/windows version/Initialize-LocalConfig.ps1
+++ b/scripts/windows version/Initialize-LocalConfig.ps1
@@ -115,9 +115,10 @@ Write-Host ""
 # Create-if-missing: .gitconfig.local holds user-owned machine state (safe.directory
 # entries, etc.), so never clobber an existing one. Regenerate deliberately with -Force.
 $localConfigExists = Test-Path $localConfigPath
+$preserved = $localConfigExists -and -not $Force
 
 try {
-    if ($localConfigExists -and -not $Force) {
+    if ($preserved) {
         Write-Host "[SKIP] .gitconfig.local already exists; preserving machine-specific config" -ForegroundColor Yellow
         Write-Host "       (regenerate from template with: Initialize-LocalConfig.ps1 -Force)" -ForegroundColor DarkGray
     }
@@ -170,18 +171,22 @@ try {
     $allowedSignersPath = Join-Path $homeDir ".ssh\allowed_signers"
     Update-AllowedSigners -AllowedSignersPath $allowedSignersPath
 
-    Write-Host ""
-    Write-Host "Local configuration includes:" -ForegroundColor Cyan
-    Write-Host "  - SSH signing program path (op-ssh-sign.exe)" -ForegroundColor Gray
-    Write-Host "  - Allowed signers file for local signature verification" -ForegroundColor Gray
-    Write-Host "  - Network safe directories (10.210.3.10, KFWS9BDC01)" -ForegroundColor Gray
-    Write-Host "  - Local development directories" -ForegroundColor Gray
-    Write-Host ""
-    Write-Host "To customize safe directories:" -ForegroundColor Cyan
-    Write-Host "  1. Edit $localConfigPath" -ForegroundColor Gray
-    Write-Host "  2. Add or modify entries in the [safe] section" -ForegroundColor Gray
-    Write-Host "  3. Save and reload git" -ForegroundColor Gray
-    Write-Host ""
+    # Describe the generated layout only when we actually wrote it; on the preserve
+    # path the user's file may differ, so this summary would be misleading.
+    if (-not $preserved) {
+        Write-Host ""
+        Write-Host "Local configuration includes:" -ForegroundColor Cyan
+        Write-Host "  - SSH signing program path (op-ssh-sign.exe)" -ForegroundColor Gray
+        Write-Host "  - Allowed signers file for local signature verification" -ForegroundColor Gray
+        Write-Host "  - Network safe directories (10.210.3.10, KFWS9BDC01)" -ForegroundColor Gray
+        Write-Host "  - Local development directories" -ForegroundColor Gray
+        Write-Host ""
+        Write-Host "To customize safe directories:" -ForegroundColor Cyan
+        Write-Host "  1. Edit $localConfigPath" -ForegroundColor Gray
+        Write-Host "  2. Add or modify entries in the [safe] section" -ForegroundColor Gray
+        Write-Host "  3. Save and reload git" -ForegroundColor Gray
+        Write-Host ""
+    }
 
     # Verify git can read the config. Validate the generated file directly with
     # --file (scope- and CWD-independent) rather than --local, which reads the

--- a/scripts/windows version/install.ps1
+++ b/scripts/windows version/install.ps1
@@ -86,7 +86,10 @@ Write-Host ""
 Write-Host "[STEP 0] Cleaning up previous installation..." -ForegroundColor Cyan
 Write-Host "-----" -ForegroundColor Cyan
 try {
-    & $cleanupScript -Force -ErrorAction Stop | Out-Null
+    # -KeepLocal: the preflight teardown must not delete ~/.gitconfig.local, which
+    # holds user-owned machine state (safe.directory entries, etc.). A full reset
+    # is available via the standalone Cleanup-GitConfig.ps1 (without -KeepLocal).
+    & $cleanupScript -Force -KeepLocal -ErrorAction Stop | Out-Null
     Write-Host "[OK] Previous installation cleaned up" -ForegroundColor Green
 }
 catch {
@@ -117,15 +120,24 @@ catch {
 }
 Write-Host ""
 
-# STEP 3: Generate local config
+# STEP 3: Generate machine-specific config (create-if-missing). .gitconfig.local
+# is user-owned state, so an existing one is preserved (never overwritten on
+# re-install, even with -Force); regenerate deliberately with
+# Initialize-LocalConfig.ps1 -Force.
 Write-Host "[STEP 3] Generating machine-specific configuration..." -ForegroundColor Cyan
 Write-Host "-----" -ForegroundColor Cyan
 try {
-    if ($Force) { & $initLocalScript -Force | Out-Null } else { & $initLocalScript | Out-Null }
-    Write-Host "[OK] Generated .gitconfig.local" -ForegroundColor Green
+    $localExisted = Test-Path (Join-Path $homeDir ".gitconfig.local")
+    & $initLocalScript | Out-Null
+    if ($localExisted) {
+        Write-Host "[OK] Preserved existing .gitconfig.local" -ForegroundColor Green
+    }
+    else {
+        Write-Host "[OK] Generated .gitconfig.local" -ForegroundColor Green
+    }
 }
 catch {
-    Write-Host "[FAIL] Could not generate .gitconfig.local: $($_.Exception.Message)" -ForegroundColor Red
+    Write-Host "[FAIL] Could not set up .gitconfig.local: $($_.Exception.Message)" -ForegroundColor Red
 }
 Write-Host ""
 

--- a/tests/Cleanup-GitConfig.Tests.ps1
+++ b/tests/Cleanup-GitConfig.Tests.ps1
@@ -20,6 +20,20 @@ Describe "Cleanup-GitConfig.ps1" {
             $scriptContent = Get-Content $scriptPath -Raw
             $scriptContent | Should -Match '\[switch\]\s*\$Help'
         }
+
+        It "Should accept -KeepLocal parameter" {
+            $scriptContent = Get-Content $scriptPath -Raw
+            $scriptContent | Should -Match '\[switch\]\s*\$KeepLocal'
+        }
+    }
+
+    Context "Preserve machine-specific config" {
+        It "Should skip removing .gitconfig.local when -KeepLocal is set" {
+            $scriptContent = Get-Content $scriptPath -Raw
+            # Guard branch present: -KeepLocal short-circuits the removal step.
+            $scriptContent | Should -Match 'if \(\$KeepLocal\)'
+            $scriptContent | Should -Match 'Preserving \.gitconfig\.local'
+        }
     }
 
     Context "Script Functionality" {

--- a/tests/Initialize-LocalConfig.Tests.ps1
+++ b/tests/Initialize-LocalConfig.Tests.ps1
@@ -136,4 +136,67 @@ Describe "Initialize-LocalConfig.ps1" {
             (Get-Content $script:scriptPath -Raw) | Should -Not -Match 'git config --local --list'
         }
     }
+
+    Context "create-if-missing (preserve existing .gitconfig.local)" {
+        BeforeEach {
+            # Same sandbox isolation as the other contexts.
+            $script:sandbox = Join-Path $TestDrive ([guid]::NewGuid().ToString("N"))
+            New-Item -ItemType Directory -Path $script:sandbox -Force | Out-Null
+
+            $script:savedUserProfile = $env:USERPROFILE
+            $script:savedHome = $env:HOME
+            $script:savedGlobal = $env:GIT_CONFIG_GLOBAL
+            $script:savedSystem = $env:GIT_CONFIG_SYSTEM
+
+            $env:USERPROFILE = $script:sandbox
+            $env:HOME = $script:sandbox
+            $env:GIT_CONFIG_GLOBAL = Join-Path $script:sandbox ".gitconfig"
+            $env:GIT_CONFIG_SYSTEM = Join-Path $script:sandbox "no-system-config"
+
+            git config --global user.email "sandbox@example.com" 2>&1 | Out-Null
+            git config --global user.signingkey "ssh-ed25519 AAAASANDBOXKEY test-comment" 2>&1 | Out-Null
+
+            $script:localPath = Join-Path $script:sandbox ".gitconfig.local"
+        }
+
+        AfterEach {
+            $env:USERPROFILE = $script:savedUserProfile
+            $env:HOME = $script:savedHome
+            $env:GIT_CONFIG_GLOBAL = $script:savedGlobal
+            $env:GIT_CONFIG_SYSTEM = $script:savedSystem
+        }
+
+        It "Should preserve an existing file when run without -Force" {
+            Set-Content -Path $script:localPath -Value "# USER-EDIT-MARKER-DO-NOT-CLOBBER"
+
+            Push-Location $script:sandbox
+            try { & $script:scriptPath 2>&1 | Out-Null } finally { Pop-Location }
+
+            $content = Get-Content $script:localPath -Raw
+            $content | Should -Match 'USER-EDIT-MARKER-DO-NOT-CLOBBER'
+            $content | Should -Not -Match 'op-ssh-sign\.exe'   # template was NOT written
+        }
+
+        It "Should still ensure allowed_signers even when preserving the config" {
+            Set-Content -Path $script:localPath -Value "# USER-EDIT-MARKER-DO-NOT-CLOBBER"
+
+            Push-Location $script:sandbox
+            try { & $script:scriptPath 2>&1 | Out-Null } finally { Pop-Location }
+
+            $allowed = Join-Path $script:sandbox ".ssh\allowed_signers"
+            $allowed | Should -Exist
+            (Get-Content $allowed -Raw) | Should -Match 'sandbox@example.com namespaces="git" ssh-ed25519 AAAASANDBOXKEY'
+        }
+
+        It "Should regenerate from template when -Force overwrites an existing file" {
+            Set-Content -Path $script:localPath -Value "# USER-EDIT-MARKER-DO-NOT-CLOBBER"
+
+            Push-Location $script:sandbox
+            try { & $script:scriptPath -Force 2>&1 | Out-Null } finally { Pop-Location }
+
+            $content = Get-Content $script:localPath -Raw
+            $content | Should -Not -Match 'USER-EDIT-MARKER-DO-NOT-CLOBBER'
+            $content | Should -Match 'op-ssh-sign\.exe'        # template WAS written
+        }
+    }
 }


### PR DESCRIPTION
Fixes #165

## Problem

`.gitconfig.local` is user-owned machine state (hand-tuned `safe.directory` entries, signing program path, credential helper), unlike `.gitconfig` which is a derived artifact regenerated from the template on every login. Re-running `install.ps1` destroyed it:

1. STEP 0 ran `Cleanup-GitConfig.ps1 -Force`, which renamed `.gitconfig.local` → `Existing.gitconfig.local.bak` (a **single-slot** backup the next install overwrites).
2. STEP 3 regenerated a fresh one from the canned template.

The interactive "Overwrite?" prompt in `Initialize-LocalConfig.ps1` never fired during install (the file was already gone by STEP 3), so `install.ps1 -Force` silently wiped customizations — and a second run lost the backup too.

## Fix — create-if-missing

- **`Initialize-LocalConfig.ps1`** — when the file exists and `-Force` is not set, **preserve** it (no prompt) instead of overwriting; still ensures `~/.ssh/allowed_signers` idempotently. `-Force` regenerates from the template.
- **`install.ps1`** — STEP 3 calls `Initialize-LocalConfig.ps1` without `-Force` (preserves even during `install -Force`); STEP 0 passes the new `-KeepLocal` to the preflight cleanup.
- **`Cleanup-GitConfig.ps1`** — adds `-KeepLocal` to skip removing `.gitconfig.local`. Standalone cleanup (full teardown) still removes it.

Explicit reset paths remain: `Cleanup-GitConfig.ps1` (without `-KeepLocal`) and `Initialize-LocalConfig.ps1 -Force`.

## Tradeoff (accepted)

Install no longer refreshes tool-managed keys inside an existing `.gitconfig.local`. Those values (excludesfile, gpg.ssh.program, allowedSignersFile, credential.helper) are machine-derived and stable, so auto-refresh benefit is near-zero; preserving user-added `safe.directory` entries is the priority. If managed-key refresh is ever needed, prefer targeted `git config --file` upserts over a full INI merge.

## Testing

```text
Initialize-LocalConfig.Tests.ps1 + Cleanup-GitConfig.Tests.ps1 + Encoding.Tests.ps1
=> 34 passed, 0 failed

New cases:
- preserve existing file when run without -Force (template NOT written)
- allowed_signers still ensured when preserving
- -Force regenerates from template (overwrites)
- Cleanup accepts -KeepLocal and guards the removal step
```

Relates to the test-isolation issue #162 (these scripts mutating the real home), which is tracked separately.