### PR TITLE
feat: adopt beads (bd) for AI task tracking

### DIFF
--- a/.beads/.gitignore
+++ b/.beads/.gitignore
@@ -1,0 +1,78 @@
+# Dolt database (managed by Dolt, not git)
+dolt/
+embeddeddolt/
+
+# Runtime files
+bd.sock
+bd.sock.startlock
+sync-state.json
+last-touched
+.exclusive-lock
+
+# Daemon runtime (lock, log, pid)
+daemon.*
+
+# Push state (runtime, per-machine)
+push-state.json
+
+# Lock files (various runtime locks)
+*.lock
+
+# Credential key (encryption key for federation peer auth — never commit)
+.beads-credential-key
+
+# Local version tracking (prevents upgrade notification spam after git ops)
+.local_version
+
+# Worktree redirect file (contains relative path to main repo's .beads/)
+# Must not be committed as paths would be wrong in other clones
+redirect
+
+# Sync state (local-only, per-machine)
+# These files are machine-specific and should not be shared across clones
+.sync.lock
+export-state/
+export-state.json
+
+# Ephemeral store (SQLite - wisps/molecules, intentionally not versioned)
+ephemeral.sqlite3
+ephemeral.sqlite3-journal
+ephemeral.sqlite3-wal
+ephemeral.sqlite3-shm
+
+# Dolt server management (auto-started by bd)
+dolt-server.pid
+dolt-server.log
+dolt-server.lock
+dolt-server.port
+dolt-server.activity
+
+# Corrupt backup directories (created by bd doctor --fix recovery)
+*.corrupt.backup/
+
+# Backup data (auto-exported JSONL, local-only)
+backup/
+
+# Per-project environment file (Dolt connection config, GH#2520)
+.env
+
+# Legacy files (from pre-Dolt versions)
+*.db
+*.db?*
+*.db-journal
+*.db-wal
+*.db-shm
+db.sqlite
+bd.db
+# NOTE: Do NOT add negation patterns here.
+# They would override fork protection in .git/info/exclude.
+# Config files (metadata.json, config.yaml) are tracked by git by default
+# since no pattern above ignores them.
+
+# Passive JSONL exports - bd rewrites these on every mutation. Sync is dolt-only
+# (refs/dolt/data), so tracking them just creates churn. See git-policies.
+issues.jsonl
+interactions.jsonl
+
+# Opt-in git-hook shims (install per-clone with 'bd hooks install'); not tracked.
+hooks/

--- a/.beads/README.md
+++ b/.beads/README.md
@@ -1,0 +1,81 @@
+# Beads - AI-Native Issue Tracking
+
+Welcome to Beads! This repository uses **Beads** for issue tracking - a modern, AI-native tool designed to live directly in your codebase alongside your code.
+
+## What is Beads?
+
+Beads is issue tracking that lives in your repo, making it perfect for AI coding agents and developers who want their issues close to their code. No web UI required - everything works through the CLI and integrates seamlessly with git.
+
+**Learn more:** [github.com/steveyegge/beads](https://github.com/steveyegge/beads)
+
+## Quick Start
+
+### Essential Commands
+
+```bash
+# Create new issues
+bd create "Add user authentication"
+
+# View all issues
+bd list
+
+# View issue details
+bd show <issue-id>
+
+# Update issue status
+bd update <issue-id> --claim
+bd update <issue-id> --status done
+
+# Sync with Dolt remote
+bd dolt push
+```
+
+### Working with Issues
+
+Issues in Beads are:
+- **Git-native**: Stored in Dolt database with version control and branching
+- **AI-friendly**: CLI-first design works perfectly with AI coding agents
+- **Branch-aware**: Issues can follow your branch workflow
+- **Always in sync**: Auto-syncs with your commits
+
+## Why Beads?
+
+✨ **AI-Native Design**
+- Built specifically for AI-assisted development workflows
+- CLI-first interface works seamlessly with AI coding agents
+- No context switching to web UIs
+
+🚀 **Developer Focused**
+- Issues live in your repo, right next to your code
+- Works offline, syncs when you push
+- Fast, lightweight, and stays out of your way
+
+🔧 **Git Integration**
+- Automatic sync with git commits
+- Branch-aware issue tracking
+- Dolt-native three-way merge resolution
+
+## Get Started with Beads
+
+Try Beads in your own projects:
+
+```bash
+# Install Beads
+curl -sSL https://raw.githubusercontent.com/steveyegge/beads/main/scripts/install.sh | bash
+
+# Initialize in your repo
+bd init
+
+# Create your first issue
+bd create "Try out Beads"
+```
+
+## Learn More
+
+- **Documentation**: [github.com/steveyegge/beads/docs](https://github.com/steveyegge/beads/tree/main/docs)
+- **Quick Start Guide**: Run `bd quickstart`
+- **Examples**: [github.com/steveyegge/beads/examples](https://github.com/steveyegge/beads/tree/main/examples)
+
+---
+
+*Beads: Issue tracking that moves at the speed of thought* ⚡

--- a/.beads/config.yaml
+++ b/.beads/config.yaml
@@ -1,0 +1,57 @@
+# Beads Configuration File
+# This file configures default behavior for all bd commands in this repository
+# All settings can also be set via environment variables (BD_* prefix)
+# or overridden with command-line flags
+
+# Issue prefix for this repository (used by bd init)
+# If not set, bd init will auto-detect from directory name
+# Example: issue-prefix: "myproject" creates issues like "myproject-1", "myproject-2", etc.
+# issue-prefix: ""
+
+# Use no-db mode: JSONL-only, no Dolt database
+# When true, bd will use .beads/issues.jsonl as the source of truth
+# no-db: false
+
+# Enable JSON output by default
+# json: false
+
+# Feedback title formatting for mutating commands (create/update/close/dep/edit)
+# 0 = hide titles, N > 0 = truncate to N characters
+# output:
+#   title-length: 255
+
+# Default actor for audit trails (overridden by BEADS_ACTOR or --actor)
+# actor: ""
+
+# Export events (audit trail) to .beads/events.jsonl on each flush/sync
+# When enabled, new events are appended incrementally using a high-water mark.
+# Use 'bd export --events' to trigger manually regardless of this setting.
+# events-export: false
+
+# Multi-repo configuration (experimental - bd-307)
+# Allows hydrating from multiple repositories and routing writes to the correct database
+# repos:
+#   primary: "."  # Primary repo (where this database lives)
+#   additional:   # Additional repos to hydrate from (read-only)
+#     - ~/beads-planning  # Personal planning repo
+#     - ~/work-planning   # Work planning repo
+
+# JSONL backup (periodic export for off-machine recovery)
+# Auto-enabled when a git remote exists. Override explicitly:
+# backup:
+#   enabled: false     # Disable auto-backup entirely
+#   interval: 15m      # Minimum time between auto-exports
+#   git-push: false    # Disable git push (export locally only)
+#   git-repo: ""       # Separate git repo for backups (default: project repo)
+
+# Integration settings (access with 'bd config get/set')
+# Non-secret keys (stored in the database):
+# - jira.url, jira.project
+# - linear.team_id
+# - github.org, github.repo
+#
+# Secret keys (stored in this file but prefer env vars to avoid git exposure):
+# - linear.api_key  → use LINEAR_API_KEY env var instead
+# - github.token    → use GITHUB_TOKEN env var instead
+
+sync.remote: "git+https://github.com/J-MaFf/gitconfig.git"

--- a/.beads/metadata.json
+++ b/.beads/metadata.json
@@ -1,0 +1,7 @@
+{
+  "database": "dolt",
+  "backend": "dolt",
+  "dolt_mode": "embedded",
+  "dolt_database": "gc",
+  "project_id": "533a5818-4fd4-44d4-aab7-c566aaf8e9a4"
+}

--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,8 @@ __pycache__/
 
 # Note: knowledge-graph.jsonl is intentionally NOT ignored
 # It will be tracked in Git for backup and sync purposes (Memory MCP server knowledge graph)
+
+# Beads / Dolt files (added by bd init)
+.dolt/
+*.db
+.beads-credential-key

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,96 @@
+# Agent Instructions
+
+This project uses **bd** (beads) for issue tracking. Run `bd prime` for full workflow context.
+
+> **Architecture in one line:** Issues live in a local Dolt database
+> (`.beads/dolt/`); cross-machine sync uses `bd dolt push/pull` (a
+> git-compatible protocol), stored under `refs/dolt/data` on your git
+> remote — separate from `refs/heads/*` where your code lives.
+> `.beads/issues.jsonl` is a passive export, not the wire protocol.
+>
+> See [SYNC_CONCEPTS.md](https://github.com/gastownhall/beads/blob/main/docs/SYNC_CONCEPTS.md)
+> for the one-screen overview and anti-patterns (don't treat JSONL as the
+> source of truth; don't `bd import` during normal operation; don't
+> reach for third-party Dolt hosting before trying the default).
+
+## Quick Reference
+
+```bash
+bd ready              # Find available work
+bd show <id>          # View issue details
+bd update <id> --claim  # Claim work atomically
+bd close <id>         # Complete work
+bd dolt push          # Push beads data to remote
+```
+
+## Non-Interactive Shell Commands
+
+**ALWAYS use non-interactive flags** with file operations to avoid hanging on confirmation prompts.
+
+Shell commands like `cp`, `mv`, and `rm` may be aliased to include `-i` (interactive) mode on some systems, causing the agent to hang indefinitely waiting for y/n input.
+
+**Use these forms instead:**
+```bash
+# Force overwrite without prompting
+cp -f source dest           # NOT: cp source dest
+mv -f source dest           # NOT: mv source dest
+rm -f file                  # NOT: rm file
+
+# For recursive operations
+rm -rf directory            # NOT: rm -r directory
+cp -rf source dest          # NOT: cp -r source dest
+```
+
+**Other commands that may prompt:**
+- `scp` - use `-o BatchMode=yes` for non-interactive
+- `ssh` - use `-o BatchMode=yes` to fail instead of prompting
+- `apt-get` - use `-y` flag
+- `brew` - use `HOMEBREW_NO_AUTO_UPDATE=1` env var
+
+<!-- BEGIN BEADS INTEGRATION v:1 profile:minimal hash:7510c1e2 -->
+## Beads Issue Tracker
+
+This project uses **bd (beads)** for issue tracking. Run `bd prime` to see full workflow context and commands.
+
+### Quick Reference
+
+```bash
+bd ready              # Find available work
+bd show <id>          # View issue details
+bd update <id> --claim  # Claim work
+bd close <id>         # Complete work
+```
+
+### Rules
+
+- Use `bd` for ALL task tracking — do NOT use TodoWrite, TaskCreate, or markdown TODO lists
+- Run `bd prime` for detailed command reference and session close protocol
+- Use `bd remember` for persistent knowledge — do NOT use MEMORY.md files
+
+**Architecture in one line:** issues live in a local Dolt DB; sync uses `refs/dolt/data` on your git remote; `.beads/issues.jsonl` is a passive export. See https://github.com/gastownhall/beads/blob/main/docs/SYNC_CONCEPTS.md for details and anti-patterns.
+
+## Session Completion
+
+**When ending a work session**, you MUST complete ALL steps below. Work is NOT complete until `git push` succeeds.
+
+**MANDATORY WORKFLOW:**
+
+1. **File issues for remaining work** - Create issues for anything that needs follow-up
+2. **Run quality gates** (if code changed) - Tests, linters, builds
+3. **Update issue status** - Close finished work, update in-progress items
+4. **PUSH TO REMOTE** - This is MANDATORY:
+   ```bash
+   git pull --rebase
+   git push
+   git status  # MUST show "up to date with origin"
+   ```
+5. **Clean up** - Clear stashes, prune remote branches
+6. **Verify** - All changes committed AND pushed
+7. **Hand off** - Provide context for next session
+
+**CRITICAL RULES:**
+- Work is NOT complete until `git push` succeeds
+- NEVER stop before pushing - that leaves work stranded locally
+- NEVER say "ready to push when you are" - YOU must push
+- If push fails, resolve and retry until it succeeds
+<!-- END BEADS INTEGRATION -->

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,19 @@
+# Changelog
+
+All notable changes to this project are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
+
+## [Unreleased]
+
+### Added
+- Adopted **beads (`bd`)** as the Dolt-backed task/memory layer beneath GitHub Issues ([#152](https://github.com/J-MaFf/gitconfig/issues/152)). The bead graph syncs via `refs/dolt/data` on `origin`; `.beads/config.yaml` and `.beads/metadata.json` are tracked while the JSONL exports and embedded Dolt DB are gitignored (dolt-only sync).
+
+### Fixed
+- Windows login scheduled task logged "No Python interpreter found" even when Python was installed: `Resolve-Python` picked the 0-byte WindowsApps app-execution-alias stub, which only resolves in an interactive session. It now skips those stubs and falls back to the real PyManager/launcher path ([#161](https://github.com/J-MaFf/gitconfig/pull/161)).
+- Non-ASCII em-dashes (U+2014) in `Update-GitConfig.ps1` and `gitconfig_helper.py` failed the ASCII Encoding tests (Windows PowerShell 5.1 compatibility) ([#164](https://github.com/J-MaFf/gitconfig/pull/164)).
+- The Pester suite mutated the real machine (overwrote `~/.gitconfig`/`~/.gitconfig.local`, toggled the login scheduled task): `run-tests.ps1` set tag filters under the wrong Pester config section so `-ExcludeTag Integration` was ignored, and two test files generated config against the real `$env:USERPROFILE`. Tests now sandbox HOME and integration tests are excluded by default ([#167](https://github.com/J-MaFf/gitconfig/pull/167)).
+
+### Changed
+- `install.ps1` no longer overwrites an existing `~/.gitconfig.local` (create-if-missing). The machine-specific config is preserved on re-install; regenerate deliberately with `Initialize-LocalConfig.ps1 -Force` ([#166](https://github.com/J-MaFf/gitconfig/pull/166)).
+- `tests/run-tests.ps1` excludes integration tests by default; opt in with `-IncludeIntegration` (run only on a real machine or VM) ([#167](https://github.com/J-MaFf/gitconfig/pull/167)).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,3 +41,49 @@ This repo targets **macOS, Linux, and Windows** — it's a cross-platform dotfil
 - Windows: Pester (`tests/run-tests.ps1`)
 - macOS/Linux: no formal test runner — validate manually or with bash assertions
 - Integration tests live in `tests/Integration.Tests.ps1` — these require a real machine or VM, not a mock environment
+
+
+<!-- BEGIN BEADS INTEGRATION v:1 profile:minimal hash:7510c1e2 -->
+## Beads Issue Tracker
+
+This project uses **bd (beads)** for issue tracking. Run `bd prime` to see full workflow context and commands.
+
+### Quick Reference
+
+```bash
+bd ready              # Find available work
+bd show <id>          # View issue details
+bd update <id> --claim  # Claim work
+bd close <id>         # Complete work
+```
+
+### Rules
+
+- Use `bd` for durable, cross-session task tracking in this repo — not ad-hoc markdown TODO lists. The **GitHub Issue stays the shippable unit**; bd is the execution/memory layer beneath it.
+- Run `bd prime` for detailed command reference and the session-close protocol
+- Use `bd remember` for **repo-scoped** knowledge that should travel with this repo; the global `~/.claude` memory (and `MEMORY.md`) remains the home for cross-repo / user-level context
+
+**Architecture in one line:** issues live in a local Dolt DB; sync uses `refs/dolt/data` on the git remote; `.beads/issues.jsonl` is a passive export. See https://github.com/gastownhall/beads/blob/main/docs/SYNC_CONCEPTS.md for details and anti-patterns.
+
+## Session Close (reconciled with the git-policies skill)
+
+> This section overrides bd's default "auto-push to main" wording to match this
+> project's git workflow. **Merges to `main` stay human-gated via PR — never
+> auto-push or auto-merge to `main`.**
+
+When ending a work session:
+
+1. **File issues for remaining work** — `bd create` for fine-grained follow-ups; open a GitHub issue for anything shippable
+2. **Run quality gates** (if code changed) — tests, linters, builds
+3. **Update issue status** — `bd close` finished work, update in-progress items
+4. **Make work durable WITHOUT merging:**
+   ```bash
+   git commit -S ...                    # signed, on the FEATURE branch
+   git push -u origin <feature-branch>  # push the branch, never main
+   bd dolt push                         # sync the bead graph (refs/dolt/data)
+   ```
+5. **Open/update the PR** (`Fixes #N`) and **stop at the merge gate** — a human approves the squash-merge
+6. **Clean up** — clear stashes, prune merged branches (`git cleanup`)
+
+Note: editing this block makes `bd setup claude --check` report it as "stale" — that is expected; do **not** run `bd setup claude` to clear it (doing so reverts this reconciliation).
+<!-- END BEADS INTEGRATION -->

--- a/STATUS.md
+++ b/STATUS.md
@@ -1,0 +1,44 @@
+# Project Status
+
+## What This Is
+
+A cross-platform tool that generates a portable `~/.gitconfig` from a version-controlled template (`.gitconfig.template`), layers machine-specific overrides via `~/.gitconfig.local`, and keeps it converged on Windows through a login scheduled task. Helper logic (`gitconfig_helper.py`) backs the custom git aliases. Windows setup is PowerShell + Pester; macOS/Linux are bash.
+
+## Current State — 2026-06-29
+
+Healthy; `main` is clean. The recent reliability and test-isolation issues are resolved, and the repo now uses **beads (`bd`)** for task tracking beneath GitHub Issues.
+
+### Components
+
+| Path | Description |
+|------|-------------|
+| `.gitconfig.template` | Source template for `~/.gitconfig` (placeholders: `{{REPO_PATH}}`, `{{HOME_DIR}}`) |
+| `gitconfig_helper.py` | Cross-platform Python 3 helper backing the git aliases |
+| `scripts/windows version/` | PowerShell setup (`install.ps1`, `Initialize-*`, `Update-GitConfig.ps1`, `Functions.ps1`) |
+| `scripts/shared/`, `scripts/mac version/`, `scripts/linux version/` | bash library + macOS/Linux entry points |
+| `tests/` | Pester tests (unit by default; integration tests are `Tag 'Integration'`, opt-in) |
+| `.beads/` | Beads task graph (Dolt-backed); syncs via `refs/dolt/data` |
+
+### Resolved Issues (recent)
+
+| Issue | Description | PR |
+|-------|-------------|----|
+| [#160](https://github.com/J-MaFf/gitconfig/issues/160) | Login task "No Python interpreter found" (WindowsApps alias stub) | [#161](https://github.com/J-MaFf/gitconfig/pull/161) |
+| [#163](https://github.com/J-MaFf/gitconfig/issues/163) | Non-ASCII em-dashes failing Encoding tests | [#164](https://github.com/J-MaFf/gitconfig/pull/164) |
+| [#165](https://github.com/J-MaFf/gitconfig/issues/165) | `install.ps1` overwrote existing `~/.gitconfig.local` | [#166](https://github.com/J-MaFf/gitconfig/pull/166) |
+| [#162](https://github.com/J-MaFf/gitconfig/issues/162) | Tests mutated the real machine config | [#167](https://github.com/J-MaFf/gitconfig/pull/167) |
+
+### Open Issues
+
+- [#152](https://github.com/J-MaFf/gitconfig/issues/152) — Adopt beads (this change; in progress).
+
+## Natural Next Steps
+
+- On each additional machine, run `bd setup claude` (the SessionStart/PreCompact hooks live in the gitignored `.claude/settings.json`) and `bd bootstrap` to hydrate the Dolt graph.
+- Consider a small cleanup of `Integration.Tests.ps1` assertions that check `.gitconfig.local` for `[commit]`/`[user]` keys that actually live in `.gitconfig`.
+
+## Prerequisites to Run
+
+- **Windows:** Git for Windows, PowerShell 7+, Python 3 (PyManager or python.org); run `scripts/windows version/install.ps1` (elevates for symlinks + scheduled task).
+- **Tests:** Pester 5+; `tests/run-tests.ps1` (add `-IncludeIntegration` only on a throwaway machine/VM).
+- **Beads:** `bd` CLI; `bd bootstrap` on a fresh clone, then `bd dolt pull` / `bd dolt push` to sync.


### PR DESCRIPTION
Fixes #152

Adopts **beads (`bd`)**, the Dolt-backed dependency-graph task/memory layer, beneath GitHub Issues — following the dolt-only convention in the `git-policies` skill.

## What changed
- **`bd init`** (prefix `gc`, embedded Dolt). Wired the Dolt remote to `origin` and ran `bd dolt push`; `refs/dolt/data` is now on origin (verified via `git ls-remote origin 'refs/dolt/*'`).
- **Tracking convention (dolt-only):** track `.beads/{config.yaml,metadata.json,.gitignore,README.md}`; gitignore the JSONL exports (`issues.jsonl`, `interactions.jsonl`), `embeddeddolt/`, and `hooks/`. `interactions.jsonl` (which `bd init` had staged) is untracked.
- **CLAUDE.md reconciliation:** the `bd`-generated block mandated auto-push to `main` and banned `MEMORY.md`. Reconciled with git-policies — session close pushes the **feature branch** + `bd dolt push`, the merge stays **human-gated**, and `bd remember` is scoped to repo-level (global `~/.claude` memory remains the home for cross-repo context).
- **Claude hooks:** SessionStart/PreCompact `bd prime` hooks registered in the **gitignored** `.claude/settings.json` (per-clone). Other machines run `bd setup claude` + `bd bootstrap`.
- **Docs:** added `STATUS.md` and `CHANGELOG.md` per git-policies.

## Notes
- Git hooks intentionally skipped (`--skip-hooks`); opt in per-clone with `bd hooks install`.
- Editing the CLAUDE.md block makes `bd setup claude --check` report it "stale" — expected; do **not** run `bd setup claude` to clear it (reverts the reconciliation).
