### PR TITLE
fix: emit /opt/homebrew safe.directory on shared Macs

### DIFF
--- a/scripts/mac version/initialize-local-config.sh
+++ b/scripts/mac version/initialize-local-config.sh
@@ -148,6 +148,20 @@ CONFIG_CONTENT+="
 	directory = $HOME_DIR/Documents/Scripts/gitconfig
 "
 
+# On a shared Mac, /opt/homebrew can be owned by a different account. git then
+# refuses to read Homebrew's repo ("detected dubious ownership"), which breaks
+# `brew update` with "fatal: not in a git directory". Trust the repo whenever
+# it exists and belongs to someone else. HOMEBREW_REPO is overridable so tests
+# can point it at a sandbox path.
+HOMEBREW_REPO="${HOMEBREW_REPO:-/opt/homebrew}"
+if [ -d "$HOMEBREW_REPO/.git" ] && [ "$(file_owner_uid "$HOMEBREW_REPO")" != "$(id -u)" ]; then
+    echo "[INFO] $HOMEBREW_REPO is owned by another user — adding it as a safe directory so brew update works."
+    CONFIG_CONTENT+="	# Homebrew's repo is owned by another account on this shared machine;
+	# without this entry git's dubious-ownership check breaks \`brew update\`.
+	directory = $HOMEBREW_REPO
+"
+fi
+
 printf '%s\n' "$CONFIG_CONTENT" > "$LOCAL_CONFIG_PATH"
 echo "[OK] Created .gitconfig.local"
 echo ""

--- a/scripts/shared/functions.sh
+++ b/scripts/shared/functions.sh
@@ -137,6 +137,13 @@ create_symlink() {
     fi
 }
 
+# Print the numeric uid that owns a path. BSD stat (macOS) and GNU stat (Linux)
+# disagree on flags, so try both.
+# Usage: file_owner_uid PATH
+file_owner_uid() {
+    stat -f %u "$1" 2>/dev/null || stat -c %u "$1" 2>/dev/null
+}
+
 # Upsert the current signing identity into an allowed_signers file so git can
 # verify SSH commit signatures locally. Without it, `git log --show-signature`
 # and `git verify-commit` report "No signature" even though commits are signed.

--- a/tests/shared/README.md
+++ b/tests/shared/README.md
@@ -6,8 +6,8 @@ linux setup scripts depend on. They complement the Windows-only Pester suite in
 
 | Suite | Runner | Covers |
 | --- | --- | --- |
-| `functions.bats` | [bats-core](https://github.com/bats-core/bats-core) | `scripts/shared/functions.sh` — `backup_file`, `create_symlink`, `update_allowed_signers`, `generate_gitconfig`, git-alias widget enable/disable |
-| `mac-initialize-local-config.bats` | bats-core | `scripts/mac version/initialize-local-config.sh` — always writes `allowedSignersFile` when signing is enabled ([#116](https://github.com/J-MaFf/gitconfig/issues/116)) |
+| `functions.bats` | [bats-core](https://github.com/bats-core/bats-core) | `scripts/shared/functions.sh` — `backup_file`, `create_symlink`, `file_owner_uid`, `update_allowed_signers`, `generate_gitconfig`, git-alias widget enable/disable |
+| `mac-initialize-local-config.bats` | bats-core | `scripts/mac version/initialize-local-config.sh` — always writes `allowedSignersFile` when signing is enabled ([#116](https://github.com/J-MaFf/gitconfig/issues/116)); trusts an other-owned Homebrew repo so `brew update` keeps working ([#169](https://github.com/J-MaFf/gitconfig/issues/169)) |
 | `test_gitconfig_helper.py` | [pytest](https://docs.pytest.org/) | `gitconfig_helper.py` — `_slugify`, `LABEL_PREFIX` selection, `_have`, `_default_branch`, `get_git_aliases` |
 
 ## Running

--- a/tests/shared/functions.bats
+++ b/tests/shared/functions.bats
@@ -84,6 +84,22 @@ teardown() {
 }
 
 # ---------------------------------------------------------------------------
+# file_owner_uid  (the helper behind issue #169)
+# ---------------------------------------------------------------------------
+
+@test "file_owner_uid prints the owning uid of a path" {
+    run file_owner_uid "$TESTDIR"
+    [ "$status" -eq 0 ]
+    [ "$output" = "$(id -u)" ]
+}
+
+@test "file_owner_uid fails silently for a missing path" {
+    run file_owner_uid "$TESTDIR/does-not-exist"
+    [ "$status" -ne 0 ]
+    [ -z "$output" ]
+}
+
+# ---------------------------------------------------------------------------
 # update_allowed_signers  (the helper behind issue #116)
 # ---------------------------------------------------------------------------
 

--- a/tests/shared/mac-initialize-local-config.bats
+++ b/tests/shared/mac-initialize-local-config.bats
@@ -1,10 +1,13 @@
 #!/usr/bin/env bats
 #
-# Bats suite for scripts/mac version/initialize-local-config.sh, focused on the
-# allowedSignersFile behavior (issue #116): on macOS, allowedSignersFile must be
-# written whenever signing is enabled — not only when 1Password's op-ssh-sign is
-# installed. Otherwise `git log --show-signature` reports "No signature" for a
-# file-based or literal signing key.
+# Bats suite for scripts/mac version/initialize-local-config.sh, covering:
+#   - allowedSignersFile behavior (issue #116): on macOS, allowedSignersFile must
+#     be written whenever signing is enabled — not only when 1Password's
+#     op-ssh-sign is installed. Otherwise `git log --show-signature` reports
+#     "No signature" for a file-based or literal signing key.
+#   - Homebrew safe.directory (issue #169): on a shared Mac where /opt/homebrew
+#     is owned by another account, the generated [safe] section must trust it
+#     or `brew update` fails with "fatal: not in a git directory".
 #
 # These tests run the real script in a mktemp sandbox with HOME and git config
 # redirected, so they never touch the developer's machine. op-ssh-sign is not on
@@ -78,4 +81,36 @@ teardown() {
     [ "$status" -eq 0 ]
     grep -qF 'excludesfile = ' "$SANDBOX/.gitconfig.local"
     grep -qF '[safe]' "$SANDBOX/.gitconfig.local"
+}
+
+@test "adds the Homebrew repo as a safe directory when it is owned by another user" {
+    mkdir -p "$SANDBOX/homebrew/.git"
+    # A non-root sandbox can't create a dir owned by someone else, so stub
+    # `id -u` to report a different uid instead — the same mismatch the script
+    # sees when /opt/homebrew belongs to another account.
+    mkdir -p "$SANDBOX/bin"
+    printf '#!/bin/sh\necho 999999\n' > "$SANDBOX/bin/id"
+    chmod +x "$SANDBOX/bin/id"
+
+    run env PATH="$SANDBOX/bin:$PATH" HOMEBREW_REPO="$SANDBOX/homebrew" \
+        bash "$SCRIPT" --force
+    [ "$status" -eq 0 ]
+
+    # The entry is present and the file still parses as valid git config.
+    git config --file "$SANDBOX/.gitconfig.local" --get-all safe.directory \
+        | grep -qFx "$SANDBOX/homebrew"
+}
+
+@test "omits the Homebrew safe directory when the repo is owned by the current user" {
+    mkdir -p "$SANDBOX/homebrew/.git"
+
+    run env HOMEBREW_REPO="$SANDBOX/homebrew" bash "$SCRIPT" --force
+    [ "$status" -eq 0 ]
+    ! grep -qF "directory = $SANDBOX/homebrew" "$SANDBOX/.gitconfig.local"
+}
+
+@test "omits the Homebrew safe directory when no Homebrew repo exists" {
+    run env HOMEBREW_REPO="$SANDBOX/no-such-brew" bash "$SCRIPT" --force
+    [ "$status" -eq 0 ]
+    ! grep -qF 'no-such-brew' "$SANDBOX/.gitconfig.local"
 }


### PR DESCRIPTION
Fixes #169

## Problem

`initialize-local-config.sh` (mac) rewrites `~/.gitconfig.local` wholesale with a hardcoded `[safe]` section, wiping the hand-added `safe.directory = /opt/homebrew` entry on every regen. On the shared Mac where `/opt/homebrew` is owned by another account, that leaves git refusing to read Homebrew's repo ("detected dubious ownership"), and `brew update` fails with `fatal: not in a git directory` / `No remote 'origin' in /opt/homebrew`. Already regressed once (Jun 25 regen).

## Changes

- **`scripts/mac version/initialize-local-config.sh`** — after the static `[safe]` entries, append `directory = $HOMEBREW_REPO` when `$HOMEBREW_REPO/.git` exists and the path is owned by a different uid than the invoking user. Defaults to `/opt/homebrew`; overridable via `HOMEBREW_REPO` for tests. No-op on single-user Macs (uids match) and Intel Macs (path absent).
- **`scripts/shared/functions.sh`** — new `file_owner_uid` helper (tries BSD `stat -f %u`, falls back to GNU `stat -c %u`) so the check also runs under the bats suite on Linux.
- **`tests/shared/`** — 5 new bats cases: `file_owner_uid` unit tests, plus the three script branches (other-owner → entry present and parseable via `git config --get-all`; same-owner → omitted; no repo → omitted). The other-owner case stubs `id -u` on `PATH`, since a non-root sandbox can't create a foreign-owned dir. README table updated.

The linux variant is intentionally untouched — Linuxbrew's repo lives at `/home/linuxbrew/.linuxbrew/Homebrew` and no Linux machine in use hits this (see issue).

## Testing

```
bats tests/shared/    # 27/27 pass (5 new)
python3 -m pytest tests/shared/test_gitconfig_helper.py   # 25/25 pass
bash -n               # both edited scripts
```

Also ran the script end-to-end on the affected machine with `HOME` sandboxed but the real `/opt/homebrew` (owned by `amymaffiola`): it prints the new `[INFO]` line and `git config --file … --get-all safe.directory` returns both entries.