### PR TITLE
fix: guard install.sh against wrong-platform runs before destructive cleanup

### DIFF
--- a/scripts/linux version/install.sh
+++ b/scripts/linux version/install.sh
@@ -51,6 +51,19 @@ EOF
     exit 0
 fi
 
+# Guard: refuse to run the Linux installer on macOS BEFORE STEP 0's destructive
+# cleanup. cleanup-gitconfig.sh --force moves an existing correct
+# ~/.gitconfig.local aside, and the guard inside initialize-local-config.sh
+# (STEP 3) only fires afterwards — so running the wrong installer would displace
+# the local config and then abort mid-install (issue #181). Fail first instead.
+# Tests set GITCONFIG_ALLOW_CROSS_OS=1 to run in a sandbox anywhere.
+if [ "$(uname -s)" = "Darwin" ] && [ "${GITCONFIG_ALLOW_CROSS_OS:-0}" != "1" ]; then
+    echo "[ERROR] This is the Linux installer but this host is macOS." >&2
+    echo "        Use 'scripts/mac version/install.sh' instead," >&2
+    echo "        or set GITCONFIG_ALLOW_CROSS_OS=1 to override (tests/sandboxes)." >&2
+    exit 1
+fi
+
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(dirname "$(dirname "$SCRIPT_DIR")")"
 HOME_DIR="$HOME"

--- a/scripts/mac version/install.sh
+++ b/scripts/mac version/install.sh
@@ -54,6 +54,19 @@ EOF
     exit 0
 fi
 
+# Guard: refuse to run the macOS installer on a non-macOS host BEFORE STEP 0's
+# destructive cleanup. cleanup-gitconfig.sh --force moves an existing correct
+# ~/.gitconfig.local aside, and the guard inside initialize-local-config.sh
+# (STEP 3) only fires afterwards — so running the wrong installer would displace
+# the local config and then abort mid-install (issue #181). Fail first instead.
+# Tests set GITCONFIG_ALLOW_CROSS_OS=1 to run in a sandbox anywhere.
+if [ "$(uname -s)" != "Darwin" ] && [ "${GITCONFIG_ALLOW_CROSS_OS:-0}" != "1" ]; then
+    echo "[ERROR] This is the macOS installer but this host is $(uname -s)." >&2
+    echo "        Use 'scripts/linux version/install.sh' instead," >&2
+    echo "        or set GITCONFIG_ALLOW_CROSS_OS=1 to override (tests/sandboxes)." >&2
+    exit 1
+fi
+
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(dirname "$(dirname "$SCRIPT_DIR")")"
 HOME_DIR="$HOME"

--- a/tests/shared/install-platform-guard.bats
+++ b/tests/shared/install-platform-guard.bats
@@ -1,0 +1,68 @@
+#!/usr/bin/env bats
+#
+# Platform guards on the install.sh wrappers (issue #181).
+#
+# PR #180 guarded initialize-local-config.sh, but install.sh runs STEP 0
+# (cleanup-gitconfig.sh --force, which moves an existing ~/.gitconfig.local to a
+# backup) BEFORE it reaches that guard at STEP 3. So running the wrong platform's
+# installer displaced the correct local config and then aborted mid-install.
+# These tests pin that the installer now aborts BEFORE any destructive step, so
+# ~/.gitconfig.local is never displaced.
+#
+# Run with:  bats tests/shared/install-platform-guard.bats
+# Requires:  bats-core and git.
+
+setup() {
+    REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)"
+    MAC_INSTALL="$REPO_ROOT/scripts/mac version/install.sh"
+    LINUX_INSTALL="$REPO_ROOT/scripts/linux version/install.sh"
+
+    SANDBOX="$(mktemp -d)"
+    export HOME="$SANDBOX"
+    # A correct machine-specific config that must survive a wrong-platform run.
+    printf 'CORRECT-LOCAL-CONFIG\n' > "$SANDBOX/.gitconfig.local"
+
+    # Stub uname so the "wrong platform" verdict can be forced on any host.
+    mkdir -p "$SANDBOX/bin"
+}
+
+teardown() {
+    rm -rf "$SANDBOX"
+}
+
+# $1 = the value `uname -s` should print
+_stub_uname() {
+    printf '#!/bin/sh\necho %s\n' "$1" > "$SANDBOX/bin/uname"
+    chmod +x "$SANDBOX/bin/uname"
+}
+
+@test "mac installer aborts on a non-macOS host before any destructive step (issue #181)" {
+    _stub_uname Linux
+    run env -u GITCONFIG_ALLOW_CROSS_OS PATH="$SANDBOX/bin:$PATH" bash "$MAC_INSTALL" --force
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"macOS installer"* ]]
+    # STEP 0 (the destructive cleanup) was never reached...
+    [[ "$output" != *"STEP 0"* ]]
+    # ...so the correct local config is untouched and no backup was created.
+    [ "$(cat "$SANDBOX/.gitconfig.local")" = "CORRECT-LOCAL-CONFIG" ]
+    run bash -c "ls \"$SANDBOX\"/*.bak \"$SANDBOX\"/Existing* 2>/dev/null"
+    [ "$status" -ne 0 ]
+}
+
+@test "linux installer aborts on macOS before any destructive step (issue #181)" {
+    _stub_uname Darwin
+    run env -u GITCONFIG_ALLOW_CROSS_OS PATH="$SANDBOX/bin:$PATH" bash "$LINUX_INSTALL" --force
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"Linux installer"* ]]
+    [[ "$output" != *"STEP 0"* ]]
+    [ "$(cat "$SANDBOX/.gitconfig.local")" = "CORRECT-LOCAL-CONFIG" ]
+    run bash -c "ls \"$SANDBOX\"/*.bak \"$SANDBOX\"/Existing* 2>/dev/null"
+    [ "$status" -ne 0 ]
+}
+
+@test "both installers carry the GITCONFIG_ALLOW_CROSS_OS escape hatch" {
+    # The override lets the sandboxed bats suites (and deliberate cross-OS runs)
+    # past the guard; a full cross-OS install is out of scope for this suite.
+    grep -qF 'GITCONFIG_ALLOW_CROSS_OS' "$MAC_INSTALL"
+    grep -qF 'GITCONFIG_ALLOW_CROSS_OS' "$LINUX_INSTALL"
+}


### PR DESCRIPTION
Fixes #181

## Problem
`install.sh` runs **STEP 0** (`cleanup-gitconfig.sh --force`, which moves an existing `~/.gitconfig.local` to a backup) **before** it reaches the platform guard inside `initialize-local-config.sh` at STEP 3. Running the wrong platform's installer therefore displaced the machine's correct local config and then aborted mid-install under `set -e` — recoverable via the backup, but the guard fired too late.

## Fix
- Added the same `uname -s` guard (with the `GITCONFIG_ALLOW_CROSS_OS=1` escape hatch, byte-for-byte consistent with the existing `initialize-local-config.sh` guards) near the top of **both** `scripts/mac version/install.sh` and `scripts/linux version/install.sh` — after `--help`, before `SCRIPT_DIR`/STEP 0, so it fails before anything destructive.
- Added `tests/shared/install-platform-guard.bats`: the wrong-platform installer exits 1, never reaches STEP 0, and leaves `~/.gitconfig.local` (and no backup) untouched; both installers carry the escape hatch.

## Testing
- Hermetic sandbox: mac installer on Linux → exit 1, config intact (`CORRECT-LOCAL-CONFIG`), no backup, STEP 0 not reached; linux installer on stubbed macOS symmetric.
- New bats suite 3/3; existing `mac`/`linux`/`functions` bats suites green; the one Pester test reading `install.sh` only asserts `enable_git_alias_widget` (unaffected).