### PR TITLE
fix: probe WindowsApps stubs as a last-resort fallback in Resolve-Python

### DIFF
--- a/scripts/windows version/Functions.ps1
+++ b/scripts/windows version/Functions.ps1
@@ -15,12 +15,14 @@
 # Why this is more than a simple Get-Command: the Python Install Manager
 # (PyManager) and the Store register their entry points as 0-byte "app execution
 # alias" reparse points under %LOCALAPPDATA%\Microsoft\WindowsApps. A working
-# alias and the not-installed placeholder are indistinguishable (both 0 bytes),
-# and an argument-less run of the placeholder opens the Store install prompt,
-# so we don't probe them: enumerate ALL matches (Get-Command -All), skip 0-byte
-# WindowsApps stubs, and add the real launcher install paths as explicit
-# fallbacks. Known gap: a Store-only install has no launcher fallback and is
-# never resolved - see #199.
+# alias and the not-installed placeholder are indistinguishable by size (both
+# 0 bytes), and an argument-less run of the placeholder opens the Store install
+# prompt - so we never probe them FIRST: enumerate ALL matches (Get-Command
+# -All), set 0-byte WindowsApps stubs aside, and add the real launcher install
+# paths as explicit fallbacks. If none of those resolve, fall back to probing
+# the WindowsApps stubs LAST (#199): with a non-empty -c argument a placeholder
+# just prints a message and exits 9009 (no UI), so this is safe and it's the
+# only way to resolve a Store-only install with no launcher.
 #
 # The probe must pass a NON-EMPTY -c argument: Windows PowerShell 5.1 (which
 # runs the login scheduled task) silently drops empty-string arguments to
@@ -29,14 +31,19 @@
 # why the old probe looked fine when tested interactively.
 function Resolve-Python {
     $candidates = [System.Collections.Generic.List[string]]::new()
+    $stubs = [System.Collections.Generic.List[string]]::new()
 
     foreach ($cmd in 'py', 'python3', 'python') {
         foreach ($g in @(Get-Command $cmd -All -ErrorAction SilentlyContinue)) {
             $src = $g.Source
             if (-not $src) { continue }
-            # Skip 0-byte WindowsApps app-execution-alias stubs (working and
-            # placeholder aliases are indistinguishable at 0 bytes; #199).
-            if ($src -like '*\Microsoft\WindowsApps\*' -and (Test-Path $src) -and ((Get-Item $src).Length -eq 0)) { continue }
+            # Set aside 0-byte WindowsApps app-execution-alias stubs rather than
+            # skipping them outright - they're probed last, below, as the only
+            # way to resolve a Store-only install (#199).
+            if ($src -like '*\Microsoft\WindowsApps\*' -and (Test-Path $src) -and ((Get-Item $src).Length -eq 0)) {
+                if (-not $stubs.Contains($src)) { $stubs.Add($src) }
+                continue
+            }
             if (-not $candidates.Contains($src)) { $candidates.Add($src) }
         }
     }
@@ -52,10 +59,21 @@ function Resolve-Python {
         }
     }
 
-    foreach ($cand in $candidates) {
-        # $null = : a candidate that writes to stdout (e.g. a .cmd wrapper
-        # echoing commands) must not leak into the function's return value.
-        $null = & $cand -c 'pass' 2>$null
+    # Real paths first, WindowsApps stubs last: a stub found alongside a real
+    # interpreter shouldn't win the resolution just because it was probed first.
+    foreach ($cand in (@($candidates) + @($stubs))) {
+        try {
+            # $null = : a candidate that writes to stdout (e.g. a .cmd wrapper
+            # echoing commands) must not leak into the function's return value.
+            # try/catch: a stub is probed here specifically because it might be
+            # broken (that's the whole reason it was previously skipped
+            # outright) - a launch failure must be treated as "this candidate
+            # doesn't work", not crash Resolve-Python's best-effort caller chain.
+            $null = & $cand -c 'pass' 2>$null
+        }
+        catch {
+            continue
+        }
         if ($LASTEXITCODE -eq 0) { return $cand }
     }
     return $null

--- a/tests/Functions.Tests.ps1
+++ b/tests/Functions.Tests.ps1
@@ -74,5 +74,68 @@ Describe "Functions.ps1" -Tag 'Unit' {
                 $env:LOCALAPPDATA = $oldLocalAppData
             }
         }
+
+        It "prefers a real interpreter over a WindowsApps stub found alongside it" -Skip:(-not $platformIsWindows) {
+            # Regression for #199: stubs are set aside and probed LAST as a
+            # Store-only fallback, not skipped outright - a stub found
+            # alongside a real interpreter must not win just because it was
+            # discovered first. A genuine app-execution-alias reparse point
+            # can't be fabricated in a test fixture (it's an OS-level MSIX
+            # registration), so this uses an intentionally-broken 0-byte file
+            # at a path shaped like the real one - if the real candidate is
+            # returned, the broken stub was never allowed to win, regardless
+            # of whether it was even probed.
+            $realDir = Join-Path $TestDrive "real-python"
+            New-Item -ItemType Directory -Force -Path $realDir | Out-Null
+            @('@echo off', 'exit /b 0') | Set-Content -Path (Join-Path $realDir "python.cmd") -Encoding ascii
+
+            $stubDir = Join-Path $TestDrive "stub\Microsoft\WindowsApps"
+            New-Item -ItemType Directory -Force -Path $stubDir | Out-Null
+            New-Item -ItemType File -Path (Join-Path $stubDir "python.exe") -Force | Out-Null
+
+            $oldPath = $env:Path
+            $oldLocalAppData = $env:LOCALAPPDATA
+            try {
+                # Stub dir listed FIRST on PATH so Get-Command would return it
+                # before the real one if ordering were not enforced correctly.
+                $env:Path = "$stubDir;$realDir"
+                $env:LOCALAPPDATA = Join-Path $TestDrive "empty-localappdata-2"
+
+                . $script:functionsPath
+                $resolved = Resolve-Python
+
+                $resolved | Should -Be (Join-Path $realDir "python.cmd")
+            }
+            finally {
+                $env:Path = $oldPath
+                $env:LOCALAPPDATA = $oldLocalAppData
+            }
+        }
+
+        It "does not crash when a WindowsApps stub fails to launch" -Skip:(-not $platformIsWindows) {
+            # A truly-invalid 0-byte file (the closest a test fixture can get
+            # to an app-execution-alias reparse point) throws when invoked,
+            # not just exits non-zero. Without the try/catch around the probe,
+            # a broken stub would crash Resolve-Python - and with it,
+            # Install-PythonDeps's best-effort caller chain.
+            $stubDir = Join-Path $TestDrive "crash-stub\Microsoft\WindowsApps"
+            New-Item -ItemType Directory -Force -Path $stubDir | Out-Null
+            New-Item -ItemType File -Path (Join-Path $stubDir "python.exe") -Force | Out-Null
+
+            $oldPath = $env:Path
+            $oldLocalAppData = $env:LOCALAPPDATA
+            try {
+                $env:Path = $stubDir
+                $env:LOCALAPPDATA = Join-Path $TestDrive "empty-localappdata-3"
+
+                . $script:functionsPath
+                { $script:resolved = Resolve-Python } | Should -Not -Throw
+                $script:resolved | Should -BeNullOrEmpty
+            }
+            finally {
+                $env:Path = $oldPath
+                $env:LOCALAPPDATA = $oldLocalAppData
+            }
+        }
     }
 }


### PR DESCRIPTION
Fixes #199

## Problem

`Resolve-Python` skipped every 0-byte WindowsApps app-execution-alias stub outright, and its explicit fallbacks only cover python.org/PyManager install paths. A machine whose only Python is the Microsoft Store package has no working candidate at all — every login run logs `[WARN] No Python interpreter found`, forever.

## Why the skip existed, and why it's now too broad

The stub-skip dates to #161, on the theory that invoking a not-yet-installed placeholder pops the Store install prompt. That's only true for an **argument-less** run. Since #197/#198, the probe always passes `-c 'pass'` — invoking a placeholder with that argument just prints a message and exits 9009, no UI. So probing stubs is now safe; they were just never given the chance.

## Fix

Set 0-byte WindowsApps aliases aside during discovery instead of discarding them, and probe them **last** — after every real candidate and explicit fallback — so a real interpreter never loses to a stub found earlier on PATH, but a Store-only install can still resolve.

## A bug this surfaced

Invoking a genuinely broken executable can **throw**, not just exit non-zero — confirmed empirically: a truly-invalid 0-byte file raises a native-command exception on launch. This was previously impossible to hit because stubs were never probed. Wrapped the probe in try/catch so any candidate failure (stub or otherwise) degrades to "try the next one" instead of crashing `Resolve-Python` and, with it, `Install-PythonDeps`'s best-effort caller chain (`install.ps1`, the login scheduled task).

## Tests

Two new cases in `tests/Functions.Tests.ps1`:
- **Ordering**: a 0-byte stub listed *first* on PATH, a working fake candidate listed after — asserts the real one still wins.
- **Crash-safety**: a stub-shaped 0-byte file as the *only* candidate — asserts `Resolve-Python` doesn't throw and returns `$null`.

A genuine app-execution-alias reparse point can't be fabricated in a test fixture (it's an OS-level MSIX registration), so these test the mechanism (ordering + crash-safety) rather than full alias resolution end-to-end.

```
pwsh 7.5:            6/6 pass
PowerShell 5.1:      6/6 pass
Full unit suite:     207/207 (18 integration excluded by design)
```

Also reverified on this machine (PyManager install, unaffected by this change): `Install-PythonDeps` under `powershell.exe -NoProfile` still prints `[OK] Python dependencies already present (rich + textual)`.