### PR TITLE
fix: install.ps1 STEP 7 verification reuses Resolve-Python

### DIFF
--- a/scripts/windows version/install.ps1
+++ b/scripts/windows version/install.ps1
@@ -218,11 +218,12 @@ foreach ($file in $verifyFiles) {
     else                  { Write-Host "[FAIL] $file missing" -ForegroundColor Red }
 }
 
-# Resolve-Python (Functions.ps1, dot-sourced in STEP 6) skips 0-byte
-# WindowsApps app-execution-alias stubs that a plain first-hit Get-Command
-# would happily return - reuse it here instead of re-resolving with weaker
-# logic, so verification can't fail against a candidate STEP 6 already knew
-# to avoid (#200).
+# Resolve-Python (Functions.ps1, dot-sourced in STEP 6) treats 0-byte
+# WindowsApps app-execution-alias stubs specially (deprioritized or skipped
+# depending on what else is available), unlike a plain first-hit Get-Command
+# chain, which would happily return one. Reuse it here instead of
+# re-resolving with weaker logic, so verification can't fail against a
+# candidate STEP 6 already knew to avoid (#200).
 $pyCmd = Resolve-Python
 
 if ($pyCmd) {

--- a/scripts/windows version/install.ps1
+++ b/scripts/windows version/install.ps1
@@ -218,10 +218,12 @@ foreach ($file in $verifyFiles) {
     else                  { Write-Host "[FAIL] $file missing" -ForegroundColor Red }
 }
 
-$pyCmd = if (Get-Command py -ErrorAction SilentlyContinue)      { "py" }
-         elseif (Get-Command python3 -ErrorAction SilentlyContinue) { "python3" }
-         elseif (Get-Command python -ErrorAction SilentlyContinue)  { "python" }
-         else { $null }
+# Resolve-Python (Functions.ps1, dot-sourced in STEP 6) skips 0-byte
+# WindowsApps app-execution-alias stubs that a plain first-hit Get-Command
+# would happily return - reuse it here instead of re-resolving with weaker
+# logic, so verification can't fail against a candidate STEP 6 already knew
+# to avoid (#200).
+$pyCmd = Resolve-Python
 
 if ($pyCmd) {
     try {

--- a/tests/Setup-GitConfig.Tests.ps1
+++ b/tests/Setup-GitConfig.Tests.ps1
@@ -83,6 +83,18 @@ Describe "install.ps1" {
             $functions | Should -Match "pip install"
             $functions | Should -Match "\[WARN\].*pip"
         }
+
+        It "STEP 7 verification should reuse Resolve-Python, not a separate first-hit Get-Command chain" {
+            # Regression for #200: a standalone `Get-Command py / python3 / python`
+            # chain can return a 0-byte WindowsApps stub that Resolve-Python
+            # (used by STEP 6's Install-PythonDeps) deliberately treats as a
+            # last resort, not a first choice - producing spurious
+            # "[WARN] Python 'rich' not importable" right after STEP 6 succeeded
+            # via the correctly resolved interpreter.
+            $scriptContent = Get-Content $script:scriptPath -Raw
+            $scriptContent | Should -Match "(?m)^\s*\`$pyCmd\s*=\s*Resolve-Python\s*$"
+            $scriptContent | Should -Not -Match "elseif\s*\(Get-Command\s+python3"
+        }
     }
 
     Context "Config Generation" {


### PR DESCRIPTION
Fixes #200

## Problem

`install.ps1` STEP 7's rich/textual verification re-resolved Python with:

```powershell
$pyCmd = if (Get-Command py -ErrorAction SilentlyContinue)      { "py" }
         elseif (Get-Command python3 -ErrorAction SilentlyContinue) { "python3" }
         elseif (Get-Command python -ErrorAction SilentlyContinue)  { "python" }
         else { $null }
```

instead of reusing the `Resolve-Python` helper STEP 6 already dot-sourced (`Functions.ps1`) and used to drive `Install-PythonDeps`. `Get-Command`'s first hit can be a 0-byte WindowsApps app-execution-alias stub — exactly what `Resolve-Python` is written to treat as a last resort (or, before #199, skip outright). On a machine where `py` is absent and `python`/`python3` resolve to the stub, STEP 7 invokes it right after STEP 6 succeeded via the *correctly* resolved interpreter, and prints a spurious `[WARN] Python 'rich' not importable` for a dependency that's actually present.

## Fix

`$pyCmd = Resolve-Python`. It's already in scope — same top-level script, dot-sourced in STEP 6 — so this removes a duplicated, weaker resolution chain rather than adding one.

## Tests

New assertion in `tests/Setup-GitConfig.Tests.ps1`: STEP 7 assigns `$pyCmd` from `Resolve-Python` and no longer carries the old `elseif (Get-Command python3 ...)` chain.

```
pwsh 7.5:            19/19 pass
PowerShell 5.1:      19/19 pass
Full unit suite:     206/206 (18 integration excluded by design)
```