### PR TITLE
fix: replace vacuous PSParser::Tokenize parse assertion with ParseFile

### DIFF
--- a/tests/Update-GitConfig.Tests.ps1
+++ b/tests/Update-GitConfig.Tests.ps1
@@ -71,7 +71,13 @@ Describe "Update-GitConfig.ps1" {
         }
 
         It "Should be a valid PowerShell script" {
-            { $null = [System.Management.Automation.PSParser]::Tokenize((Get-Content $script:scriptPath -Raw), [ref]$null) } | Should -Not -Throw
+            # PSParser::Tokenize never throws on syntax errors (it reports them
+            # via the discarded [ref] parameter), so a Should -Not -Throw around
+            # it is vacuous - an unparseable script would still pass (#201).
+            # Capture and count parse errors instead.
+            $parseErrors = $null
+            $null = [System.Management.Automation.Language.Parser]::ParseFile($script:scriptPath, [ref]$null, [ref]$parseErrors)
+            $parseErrors.Count | Should -Be 0
         }
 
         It "Should accept RepoPath parameter" {


### PR DESCRIPTION
Fixes #201

## Problem

`tests/Update-GitConfig.Tests.ps1`'s "Should be a valid PowerShell script" test wraps `PSParser::Tokenize` in `Should -Not -Throw`:

\`\`\`powershell
{ \$null = [System.Management.Automation.PSParser]::Tokenize((Get-Content \$script:scriptPath -Raw), [ref]\$null) } | Should -Not -Throw
\`\`\`

`Tokenize` never throws on syntax errors — it reports them via the `[ref]` out-parameter, which this test discards as `[ref]\$null`. The assertion can never fail, so an unparseable `Update-GitConfig.ps1` would still pass this test.

## Fix

Replaced with `Language.Parser::ParseFile` + a captured error-count assertion — the same pattern already used in `Encoding.Tests.ps1`, and (since #198) `Functions.Tests.ps1`. Repo-wide grep confirms this was the only remaining occurrence of the vacuous pattern.

## Tests

\`\`\`
pwsh 7.5:            27/27 pass
PowerShell 5.1:      27/27 pass
Full unit suite:     205/205 (18 integration excluded by design)
\`\`\`