### PR TITLE
fix: resolve Python via py -> python3 -> python in Integration.Tests.ps1

### DIFF
--- a/tests/Integration.Tests.ps1
+++ b/tests/Integration.Tests.ps1
@@ -17,6 +17,28 @@ BeforeAll {
 
     # Choose PowerShell executable based on platform
     $script:pwshExe = if ($script:platformIsWindows) { "powershell" } else { "pwsh" }
+
+    # Resolve the Python interpreter per the repo rule: py -> python3 -> python.
+    # Never bare `python` first - it's the WindowsApps stub on Windows (exits
+    # 9009 or pops the Store prompt) and absent on macOS/Linux (#202). Mirrors
+    # gitconfig_helper.Tests.ps1's Resolve-TestPython; kept local here since
+    # this file's platform reach (macOS/Linux/Windows) doesn't match
+    # Resolve-Python in the Windows-only Functions.ps1.
+    $script:python = foreach ($name in 'py', 'python3', 'python') {
+        if (Get-Command $name -CommandType Application -ErrorAction SilentlyContinue) {
+            $name
+            break
+        }
+    }
+}
+
+Describe "Integration.Tests.ps1 Python resolution" -Tag 'Unit' {
+    # Static check so a regression is caught by the default (Integration-excluded)
+    # suite, not only when someone opts into -IncludeIntegration (#202).
+    It "does not invoke bare 'python' - must resolve via py -> python3 -> python" {
+        $content = Get-Content $PSCommandPath -Raw
+        $content | Should -Not -Match "(?m)^\s*&\s+python\s"
+    }
 }
 
 Describe "GitConfig Integration" -Tag 'Integration' {
@@ -136,8 +158,12 @@ Describe "GitConfig Helper Script" -Tag 'Integration' {
     }
 
     It "gitconfig_helper.py should be valid Python" {
+        if (-not $script:python) {
+            Set-ItResult -Skipped -Because "no Python interpreter found (py/python3/python)"
+            return
+        }
         $helperPath = Join-Path $script:repoRoot "gitconfig_helper.py"
-        & python -m py_compile $helperPath 2>&1 | Out-Null
+        & $script:python -m py_compile $helperPath 2>&1 | Out-Null
         $LASTEXITCODE | Should -Be 0
     }
 }


### PR DESCRIPTION
Fixes #202

## Problem

"gitconfig_helper.py should be valid Python" in \`tests/Integration.Tests.ps1\` invoked bare \`python -m py_compile\`, bypassing the repo's own resolution rule (stated in \`gitconfig_helper.Tests.ps1\`: never bare \`python\` first — it's the WindowsApps stub on Windows, absent on macOS/Linux). On a machine where Python was installed via the py launcher only (no bare \`python\`/\`python3\` on PATH except the Store stub), \`python\` resolves to the 0-byte stub: \`py_compile\` exits 9009 (errors swallowed by \`2>&1 | Out-Null\`), and the test fails spuriously for a helper script that's actually valid.

## Fix

Added the same \`py -> python3 -> python\` resolution \`gitconfig_helper.Tests.ps1\` already uses (\`Resolve-TestPython\`) to this file's top-level \`BeforeAll\`, and skip the test gracefully if no interpreter is found at all, rather than fail. Kept this resolution local rather than reusing \`Functions.ps1\`'s \`Resolve-Python\` — that helper is Windows-only (its WindowsApps-stub-awareness and \`%LOCALAPPDATA%\` fallbacks are meaningless on macOS/Linux), while this test file spans all three platforms.

## Tests

Also added a \`Tag 'Unit'\` static check (self-referential \`Get-Content \$PSCommandPath\`) so a regression back to bare \`python\` is caught by the *default* suite — this file's other tests are \`Tag 'Integration'\` and excluded unless \`-IncludeIntegration\` is passed.

\`\`\`
New Unit-tagged check:  1/1 pass, both hosts
Full unit suite:        206/206 (18 integration excluded by design)
Integration-tagged run: "should be valid Python" passes via the resolved
                         interpreter (614ms, not skipped) - verified on
                         this machine with -IncludeIntegration
\`\`\`